### PR TITLE
Shovill min contig length to 200

### DIFF
--- a/tasks/task_denovo_assembly.wdl
+++ b/tasks/task_denovo_assembly.wdl
@@ -6,6 +6,7 @@ task shovill_pe {
     File  read2_cleaned
     String  samplename
     String  docker="staphb/shovill:1.1.0"
+    Int min_contig_length=200
   }
 
   command <<<
@@ -13,7 +14,8 @@ task shovill_pe {
     shovill \
     --outdir out \
     --R1 ~{read1_cleaned} \
-    --R2 ~{read2_cleaned}
+    --R2 ~{read2_cleaned} \
+    --minlen ~{min_contig_length}
     mv out/contigs.fa out/~{samplename}_contigs.fasta
     mv out/contigs.gfa out/~{samplename}_contigs.gfa
   >>>


### PR DESCRIPTION
This PR creates an optional `min_contig_length` input value for the shovil task (included in the apollo workflow) and sets the default value to 200