### PR TITLE
Jl gambit update dev

### DIFF
--- a/tasks/task_taxon_id.wdl
+++ b/tasks/task_taxon_id.wdl
@@ -10,6 +10,7 @@ task gambit {
   command <<<
     # capture date and version
     date | tee DATE
+    gambit --version | tee GAMBIT_VERSION
 
     gambit query -o ~{samplename}_gambit.csv ~{assembly}
 
@@ -37,6 +38,7 @@ task gambit {
   >>>
 
   output {
+    String gambit_version = read_string("GAMBIT_VERSION")
     File gambit_report = "~{samplename}_gambit.csv"
     String gambit_docker = docker
     String pipeline_date = read_string("DATE")

--- a/tasks/task_taxon_id.wdl
+++ b/tasks/task_taxon_id.wdl
@@ -20,16 +20,16 @@ task gambit {
     with open("~{samplename}_gambit.csv",'r') as csv_file:
       csv_reader = list(csv.DictReader(csv_file, delimiter=","))
       for line in csv_reader:
-        with open ("GAMBIT_DISTANCE", 'wt') as gambit_distance:
+        with open ("CLOSEST_DISTANCE", 'wt') as gambit_distance:
           top_score=float(line["closest.distance"])
           top_score="{:.4f}".format(top_score)
           gambit_distance.write(str(top_score))
-        with open("GAMBIT_RANK", 'wt') as gambit_rank:
+        with open("PREDICTED_RANK", 'wt') as gambit_rank:
           predicted_rank=line["predicted.rank"]
           if not predicted_rank:
             predicted_rank="None"
           gambit_rank.write(predicted_rank)
-        with open("GAMBIT_TAXON", 'wt') as gambit_taxon:
+        with open("PREDICTED_TAXON", 'wt') as gambit_taxon:
           predicted_taxon=line["predicted.name"]
           if not predicted_taxon:
             predicted_taxon="None"
@@ -39,12 +39,12 @@ task gambit {
 
   output {
     String gambit_version = read_string("GAMBIT_VERSION")
-    File gambit_report = "~{samplename}_gambit.csv"
-    String gambit_docker = docker
+    String docker_image = docker
     String pipeline_date = read_string("DATE")
-    Float gambit_distance = read_float("GAMBIT_DISTANCE")
-    String gambit_taxon = read_string("GAMBIT_TAXON")
-    String gambit_rank = read_string("GAMBIT_RANK")
+    File report_file = "~{samplename}_gambit.csv"
+    Float closest_distance = read_float("CLOSEST_DISTANCE")
+    String predicted_taxon = read_string("PREDICTED_TAXON")
+    String predicted_rank = read_string("PREDICTED_RANK")
   }
 
   runtime {

--- a/tasks/task_taxon_id.wdl
+++ b/tasks/task_taxon_id.wdl
@@ -5,22 +5,13 @@ task gambit {
     File assembly
     String samplename
     String docker = "quay.io/staphb/gambit:0.3.0"
-    File gambit_db_genomes
-    File gambit_db_signatures
   }
-  String gambit_db_genomes_name = basename(gambit_db_genomes, ".db")
-  String gambit_db_signatures_name = basename(gambit_db_signatures, ".h5")
 
   command <<<
     # capture date and version
     date | tee DATE
 
-    # create gambit database dir
-    mkdir ./gambit_database
-    cp ~{gambit_db_genomes} ./gambit_database
-    cp ~{gambit_db_signatures} ./gambit_database
-
-    gambit -d .//gambit_database query -o ~{samplename}_gambit.csv ~{assembly}
+    gambit query -o ~{samplename}_gambit.csv ~{assembly}
 
     python3 <<CODE
     import csv

--- a/workflows/wf_apollo_illumina_pe.wdl
+++ b/workflows/wf_apollo_illumina_pe.wdl
@@ -82,11 +82,10 @@ workflow apollo_illumina_pe {
     Float? r2_mean_q = cg_pipeline.r2_mean_q
     Float est_coverage = cg_pipeline.est_coverage
 
-    File gambit_report = gambit.gambit_report
-    String gambit_docker = gambit.gambit_docker
-    Float gambit_distance = gambit.gambit_distance
-    String gambit_taxon = gambit.gambit_taxon
-    String gambit_rank = gambit.gambit_rank
-
+    File gambit_report = gambit.report_file
+    String gambit_docker = gambit.docker_image
+    Float gambit_closest_distance = gambit.closest_distance
+    String gambit_predicted_taxon = gambit.predicted_taxon
+    String gambit_predicted_rank = gambit.predicted_rank
   }
 }

--- a/workflows/wf_apollo_illumina_pe.wdl
+++ b/workflows/wf_apollo_illumina_pe.wdl
@@ -53,7 +53,7 @@ workflow apollo_illumina_pe {
   output {
     String apollo_illumina_pe_version = version_capture.phbg_version
     String apollo_illumina_pe_analysis_date = version_capture.date
-        
+
     String seq_platform	=	seq_method
 
     Int fastqc_raw1 = read_QC_trim.fastqc_raw1
@@ -70,18 +70,18 @@ workflow apollo_illumina_pe {
     File assembly_fasta = shovill_pe.assembly_fasta
     File contigs_gfa = shovill_pe.contigs_gfa
     String shovill_pe_version = shovill_pe.shovill_version
-    
+
     File quast_report = quast.quast_report
     String quast_version = quast.version
     Int genome_length = quast.genome_length
     Int number_contigs = quast.number_contigs
-    
+
     File cg_pipeline_report = cg_pipeline.cg_pipeline_report
     String cg_pipeline_docker = cg_pipeline.cg_pipeline_docker
     Float r1_mean_q = cg_pipeline.r1_mean_q
     Float? r2_mean_q = cg_pipeline.r2_mean_q
     Float est_coverage = cg_pipeline.est_coverage
-    
+
     File gambit_report = gambit.gambit_report
     String gambit_docker = gambit.gambit_docker
     Float gambit_distance = gambit.gambit_distance

--- a/workflows/wf_apollo_illumina_se.wdl
+++ b/workflows/wf_apollo_illumina_se.wdl
@@ -73,11 +73,10 @@ workflow apollo_illumina_pe {
     Float r1_mean_q = cg_pipeline.r1_mean_q
     Float est_coverage = cg_pipeline.est_coverage
 
-    File gambit_report = gambit.gambit_report
-    String gambit_docker = gambit.gambit_docker
-    Float gambit_distance = gambit.gambit_distance
-    String gambit_taxon = gambit.gambit_taxon
-    String gambit_rank = gambit.gambit_rank
-
+    File gambit_report = gambit.report_file
+    String gambit_docker = gambit.docker_image
+    Float gambit_closest_distance = gambit.closest_distance
+    String gambit_predicted_taxon = gambit.predicted_taxon
+    String gambit_predicted_rank = gambit.predicted_rank
   }
 }

--- a/workflows/wf_apollo_illumina_se.wdl
+++ b/workflows/wf_apollo_illumina_se.wdl
@@ -49,30 +49,30 @@ workflow apollo_illumina_pe {
   output {
     String apollo_illumina_pe_version = version_capture.phbg_version
     String apollo_illumina_pe_analysis_date = version_capture.date
-        
+
     String seq_platform	=	seq_method
 
     Int fastqc_raw = read_QC_trim.fastqc_number_reads
     String fastqc_version = read_QC_trim.fastqc_version
     Int fastqc_clean = read_QC_trim.fastqc_clean_number_reads
-    
+
     String trimmomatic_version = read_QC_trim.trimmomatic_version
     String bbduk_docker = read_QC_trim.bbduk_docker
 
     File assembly_fasta = shovill_se.assembly_fasta
     File contigs_gfa = shovill_se.contigs_gfa
     String shovill_se_version = shovill_se.shovill_version
-    
+
     File quast_report = quast.quast_report
     String quast_version = quast.version
     Int genome_length = quast.genome_length
     Int number_contigs = quast.number_contigs
-    
+
     File cg_pipeline_report = cg_pipeline.cg_pipeline_report
     String cg_pipeline_docker = cg_pipeline.cg_pipeline_docker
     Float r1_mean_q = cg_pipeline.r1_mean_q
     Float est_coverage = cg_pipeline.est_coverage
-    
+
     File gambit_report = gambit.gambit_report
     String gambit_docker = gambit.gambit_docker
     Float gambit_distance = gambit.gambit_distance

--- a/workflows/wf_apollo_illumina_se.wdl
+++ b/workflows/wf_apollo_illumina_se.wdl
@@ -6,7 +6,7 @@ import "../tasks/task_taxon_id.wdl" as taxon_id
 import "../tasks/task_denovo_assembly.wdl" as assembly
 import "../tasks/task_versioning.wdl" as versioning
 
-workflow apollo_illumina_pe {
+workflow apollo_illumina_se {
   meta {
     description: "De-novo genome assembly, taxonomic ID, and QC of paired-end bacterial NGS data"
   }

--- a/workflows/wf_gambit_query.wdl
+++ b/workflows/wf_gambit_query.wdl
@@ -20,10 +20,10 @@ workflow gambit_query {
     String gambit_query_wf_version = version_capture.phbg_version
     String gambit_query_wf_analysis_date = version_capture.date
 
-    File gambit_report = gambit.gambit_report
-    String gambit_docker = gambit.gambit_docker
-    Float gambit_distance = gambit.gambit_distance
-    String gambit_taxon = gambit.gambit_taxon
-    String gambit_rank = gambit.gambit_rank
+    File gambit_report = gambit.report_file
+    String gambit_docker = gambit.docker_image
+    Float gambit_closest_distance = gambit.closest_distance
+    String gambit_predicted_taxon = gambit.predicted_taxon
+    String gambit_predicted_rank = gambit.predicted_rank
   }
 }

--- a/workflows/wf_gambit_query.wdl
+++ b/workflows/wf_gambit_query.wdl
@@ -25,7 +25,5 @@ workflow gambit_query {
     Float gambit_distance = gambit.gambit_distance
     String gambit_taxon = gambit.gambit_taxon
     String gambit_rank = gambit.gambit_rank
-    String gambit_db_genomes_version = gambit.gambit_db_genomes_version
-    String gambit_db_signatures_version = gambit.gambit_db_signatures_version
   }
 }

--- a/workflows/wf_gambit_query.wdl
+++ b/workflows/wf_gambit_query.wdl
@@ -4,28 +4,28 @@ import "../tasks/task_taxon_id.wdl" as taxon_id
 import "../tasks/task_versioning.wdl" as versioning
 
 workflow gambit_query {
-	input {
-		File assembly_fasta
+  input {
+    File assembly_fasta
     String samplename
-	}
-	call taxon_id.gambit {
-		input:
-			assembly = assembly_fasta,
+  }
+  call taxon_id.gambit {
+    input:
+      assembly = assembly_fasta,
       samplename = samplename,
-	}
-	call versioning.version_capture{
+  }
+  call versioning.version_capture {
     input:
   }
   output {
     String gambit_query_wf_version = version_capture.phbg_version
     String gambit_query_wf_analysis_date = version_capture.date
-		
-		File gambit_report = gambit.gambit_report
-		String gambit_docker = gambit.gambit_docker
-		Float gambit_distance = gambit.gambit_distance
-		String gambit_taxon = gambit.gambit_taxon
-		String gambit_rank = gambit.gambit_rank
-		String gambit_db_genomes_version = gambit.gambit_db_genomes_version
-		String gambit_db_signatures_version = gambit.gambit_db_signatures_version
-    }
+
+    File gambit_report = gambit.gambit_report
+    String gambit_docker = gambit.gambit_docker
+    Float gambit_distance = gambit.gambit_distance
+    String gambit_taxon = gambit.gambit_taxon
+    String gambit_rank = gambit.gambit_rank
+    String gambit_db_genomes_version = gambit.gambit_db_genomes_version
+    String gambit_db_signatures_version = gambit.gambit_db_signatures_version
+  }
 }


### PR DESCRIPTION
Updates to GAMBIT task:

* Use database in docker image, instead of files supplied by workflow
* Output result of `gambit --version`
* Renamed task outputs ("gambit" prefix to output variables not necessary)
* Workflow name in `workflows/apollo_illumina_se` was still `apollo_illumina_pe`, assume from copy-paste. Corrected.