### PR TITLE
QC screen

### DIFF
--- a/tasks/quality_control/task_screen.wdl
+++ b/tasks/quality_control/task_screen.wdl
@@ -1,0 +1,149 @@
+version 1.0
+
+task check_reads {
+  input {
+    File read1
+    File read2
+    Int? min_reads = 7472
+  }
+  command <<<
+    # set cat command based on compression
+    if [[ "~{read1}" == *".gz" ]] ; then
+      cat_reads="zcat"
+    else
+      cat_reads="cat"
+    fi
+
+    # count number of reads
+    read1_num=`eval "$cat_reads ~{read1}" | awk '{s++}END{print s/4}'`
+    read2_num=`eval "$cat_reads ~{read2}" | awk '{s++}END{print s/4}'`
+
+    # if below the min_read number, set pass/fail flag
+    if [ "${read1_num}" -le "~{min_reads}" ] || [ "${read2_num}" -le "~{min_reads}" ]; then
+      flag="FAIL; the number of reads is below the minimum of ~{min_reads}"
+    else
+      flag="PASS"
+    fi
+
+    echo $flag | tee FLAG
+  >>>
+  output {
+    String pass_screen = read_string("FLAG")
+  }
+  runtime { ### NOT SURE
+    docker: ""
+    memory: "2 GB"
+    cpu: 2
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  }
+}
+
+task check_basepairs {
+  input {
+    File read1
+    File read2
+    Int? min_basepairs = 2241820
+  }
+  command <<<
+    # set cat command based on compression
+    if [[ "~{read1}" == *".gz" ]] ; then
+      cat_reads="zcat"
+    else
+      cat_reads="cat"
+    fi
+
+    read1_bp=`eval "${cat_reads} ~{read1}" | paste - - - - | cut -f2 | tr -d '\n' | wc -c`
+    read2_bp=`eval "${cat_reads} ~{read2}" | paste - - - - | cut -f2 | tr -d '\n' | wc -c`
+
+    if [ "${read1_bp}" -le "~{min_basepairs}" ] || [ "${read2_bp}" -le "~{min_basepairs}" ] ; then
+      flag="FAIL; the number of basepairs is below the minimum of ~{min_basepairs}"
+    else
+      flag="PASS"
+    fi
+
+    echo $flag | tee FLAG
+  >>>
+  output {
+    String pass_screen = read_string("FLAG")
+  }
+  runtime { ### NOT SURE
+    docker: ""
+    memory: "2 GB"
+    cpu: 2
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  }
+}
+
+task check_genome_size {
+  input {
+    File assembly_Fasta
+    Int? min_genome_size = 100000
+    Int? max_genome_size = 18040666
+  }
+  command <<<
+  # Robert used mash sketch to estimate genome size here.
+  echo "test"
+  >>>
+  output {
+    String pass_screen = read_string("FLAG")
+  }
+  runtime { ### NOT SURE
+    docker: ""
+    memory: "2 GB"
+    cpu: 2
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  }
+}
+
+task check_coverage {
+  input {
+    File read1
+    File read2
+    Int? min_coverage = 10
+  }
+  command <<<
+  echo "test"
+  >>>
+  # was this done before or after?
+  output {
+    String pass_screen = read_string("FLAG")
+  }
+  runtime { ### NOT SURE
+    docker: ""
+    memory: "2 GB"
+    cpu: 2
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  } 
+}
+
+task check_proportion {
+  input {
+    File read1
+    File read2
+    Float? min_proportion = 0.5
+  }
+  command <<<
+  echo "test"
+  >>>
+  # i can't remember what this was used for
+  output {
+    String pass_screen = read_string("FLAG")
+  }
+  runtime { ### NOT SURE
+    docker: ""
+    memory: "2 GB"
+    cpu: 2
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  }
+}
+

--- a/tasks/quality_control/task_screen.wdl
+++ b/tasks/quality_control/task_screen.wdl
@@ -42,12 +42,12 @@ task check_reads {
       percent_read1=$((read1_num / read2_num * 100))
       percent_read2=$((read2_num / read1_num * 100))
 
-      # compare proportion here 
+      # compare proportion of reads with one another; if less than 50% quit
       if [ "$flag" = "PASS" ] ; then
-        if [ "percent_read1" -lt "~min_proportion" ] ; then
-          flag="FAIL; more than 50 percent of the reads are present in ~{read2} than ~{read1}"
-        elif [ "$percent_read2" -lt "~min_proportion" ] ; then
-          flag="FAIL; more than 50 percent of the reads are present in ~{read1} than ~{read2}"
+        if [ "$percent_read1" -lt "~{min_proportion}" ] ; then
+          flag="FAIL; more than 50 percent of the total reads are found in ~{read2} compared to ~{read1}"
+        elif [ "$percent_read2" -lt "~{min_proportion}" ] ; then
+          flag="FAIL; more than 50 percent of the total reads are found in ~{read1} compared to ~{read2}"
         else
           flag="PASS"
         fi
@@ -76,7 +76,7 @@ task check_reads {
       if [ "${flag}" = "PASS" ]; then
         # determine genome size
               
-        # First Pass
+        # First Pass; assuming average depth
         mash sketch -o test -k 31 -m 3 -r ~{read1} ~{read2} > mash-output.txt 2>&1
         grep "Estimated genome size:" mash-output.txt | \
           awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_size_output
@@ -118,11 +118,11 @@ task check_reads {
             flag="FAIL; the estimated coverage is less than the minimum of ~{min_coverage}x"
           else
             flag="PASS"
-          fi    
-        fi    
+          fi  # estuimated coverage check close
+        fi # estimated genome size check close
 
     
-      fi # third and fourth check close
+      fi # mash sketch check close
 
     fi # closes if skip_screen == "False" check
     echo $flag | tee FLAG

--- a/tasks/quality_control/task_screen.wdl
+++ b/tasks/quality_control/task_screen.wdl
@@ -5,145 +5,140 @@ task check_reads {
     File read1
     File read2
     Int? min_reads = 7472
-  }
-  command <<<
-    # set cat command based on compression
-    if [[ "~{read1}" == *".gz" ]] ; then
-      cat_reads="zcat"
-    else
-      cat_reads="cat"
-    fi
-
-    # count number of reads
-    read1_num=`eval "$cat_reads ~{read1}" | awk '{s++}END{print s/4}'`
-    read2_num=`eval "$cat_reads ~{read2}" | awk '{s++}END{print s/4}'`
-
-    # if below the min_read number, set pass/fail flag
-    if [ "${read1_num}" -le "~{min_reads}" ] || [ "${read2_num}" -le "~{min_reads}" ]; then
-      flag="FAIL; the number of reads is below the minimum of ~{min_reads}"
-    else
-      flag="PASS"
-    fi
-
-    echo $flag | tee FLAG
-  >>>
-  output {
-    String pass_screen = read_string("FLAG")
-  }
-  runtime { ### NOT SURE
-    docker: ""
-    memory: "2 GB"
-    cpu: 2
-    disks: "local-disk 100 SSD"
-    preemptible: 0
-    maxRetries: 3
-  }
-}
-
-task check_basepairs {
-  input {
-    File read1
-    File read2
     Int? min_basepairs = 2241820
-  }
-  command <<<
-    # set cat command based on compression
-    if [[ "~{read1}" == *".gz" ]] ; then
-      cat_reads="zcat"
-    else
-      cat_reads="cat"
-    fi
-
-    read1_bp=`eval "${cat_reads} ~{read1}" | paste - - - - | cut -f2 | tr -d '\n' | wc -c`
-    read2_bp=`eval "${cat_reads} ~{read2}" | paste - - - - | cut -f2 | tr -d '\n' | wc -c`
-
-    if [ "${read1_bp}" -le "~{min_basepairs}" ] || [ "${read2_bp}" -le "~{min_basepairs}" ] ; then
-      flag="FAIL; the number of basepairs is below the minimum of ~{min_basepairs}"
-    else
-      flag="PASS"
-    fi
-
-    echo $flag | tee FLAG
-  >>>
-  output {
-    String pass_screen = read_string("FLAG")
-  }
-  runtime { ### NOT SURE
-    docker: ""
-    memory: "2 GB"
-    cpu: 2
-    disks: "local-disk 100 SSD"
-    preemptible: 0
-    maxRetries: 3
-  }
-}
-
-task check_genome_size {
-  input {
-    File assembly_Fasta
     Int? min_genome_size = 100000
     Int? max_genome_size = 18040666
-  }
-  command <<<
-  # Robert used mash sketch to estimate genome size here.
-  echo "test"
-  >>>
-  output {
-    String pass_screen = read_string("FLAG")
-  }
-  runtime { ### NOT SURE
-    docker: ""
-    memory: "2 GB"
-    cpu: 2
-    disks: "local-disk 100 SSD"
-    preemptible: 0
-    maxRetries: 3
-  }
-}
-
-task check_coverage {
-  input {
-    File read1
-    File read2
     Int? min_coverage = 10
+    Int? min_proportion = 50
+    Boolean? skip_screen = false 
   }
   command <<<
-  echo "test"
+    flag="PASS"
+
+    if [[ "~{skip_screen}" = "false" ]] ; then
+      
+      # set cat command based on compression
+      if [[ "~{read1}" == *".gz" ]] ; then
+        cat_reads="zcat"
+      else
+        cat_reads="cat"
+      fi
+
+      # count number of reads
+      # sometimes fastqs do not have 4 lines per read, so this might fail one day
+      read1_num=`eval "$cat_reads ~{read1}" | awk '{s++}END{print s/4}'`
+      read2_num=`eval "$cat_reads ~{read2}" | awk '{s++}END{print s/4}'`
+      # awk '{s++}END{print s/4' counts the number of lines and divides them by 4
+      # key assumption: in fastq there will be four lines per read
+
+      # if below the min_read number, set pass/fail flag
+      if [ "${read1_num}" -le "~{min_reads}" ] || [ "${read2_num}" -le "~{min_reads}" ]; then
+        flag="FAIL; the number of reads is below the minimum of ~{min_reads}"
+      else
+        flag="PASS"
+      fi
+
+      # set proportion variables for easy comparison
+      percent_read1=$((read1_num / read2_num * 100))
+      percent_read2=$((read2_num / read1_num * 100))
+
+      # compare proportion here 
+      if [ "$flag" = "PASS" ] ; then
+        if [ "percent_read1" -lt "~min_proportion" ] ; then
+          flag="FAIL; more than 50 percent of the reads are present in ~{read2} than ~{read1}"
+        elif [ "$percent_read2" -lt "~min_proportion" ] ; then
+          flag="FAIL; more than 50 percent of the reads are present in ~{read1} than ~{read2}"
+        else
+          flag="PASS"
+        fi
+      fi
+
+      # if passes first check, continue to second check
+      if [ "${flag}" = "PASS" ]; then
+        # count number of basepairs
+        # this only works if the fastq has 4 lines per read, so this might fail one day
+        read1_bp=`eval "${cat_reads} ~{read1}" | paste - - - - | cut -f2 | tr -d '\n' | wc -c`
+        read2_bp=`eval "${cat_reads} ~{read2}" | paste - - - - | cut -f2 | tr -d '\n' | wc -c`
+        # paste - - - - (print 4 consecutive lines in one row, tab delimited)
+        # cut -f2 print only the second column (the second line of the fastq 4-line)
+        # tr -d '\n' removes line endings
+        # wc -c counts characters
+
+        # if below the min_basepairs number, set pass/fail flag
+        if [ "${read1_bp}" -le "~{min_basepairs}" ] || [ "${read2_bp}" -le "~{min_basepairs}" ] ; then
+          flag="FAIL; the number of basepairs is below the minimum of ~{min_basepairs}"
+        else
+          flag="PASS"
+        fi    
+      fi # closes second check
+
+      #if passes second check, continue to third check
+      if [ "${flag}" = "PASS" ]; then
+        # determine genome size
+              
+        # First Pass
+        mash sketch -o test -k 31 -m 3 -r ~{read1} ~{read2} > mash-output.txt 2>&1
+        grep "Estimated genome size:" mash-output.txt | \
+          awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_size_output
+        grep "Estimated coverage:" mash-output.txt | \
+          awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
+        rm -rf test.msh
+        rm -rf mash-output.txt
+        estimated_genome_size=`head -n1 genome_size_output`
+        estimated_coverage=`head -n1 coverage_output`
+
+        # Check if second pass is needed
+        if [ ${estimated_genome_size} -gt "~{max_genome_size}" ] || [ ${estimated_genome_size} -lt "~{min_genome_size}" ] ; then
+          # Probably high coverage, try increasing number of kmer copies to 10
+          M="-m 10"
+          if [ ${estimated_genome_size} -lt "~{min_genome_size}" ]; then
+            # Probably low coverage, try decreasing the number of kmer copies to 1
+            M="-m 1"
+          fi
+          mash sketch -o test -k 31 ${M} -r ~{read1} ~{read2} > mash-output.txt 2>&1
+          grep "Estimated genome size:" mash-output.txt | \
+            awk '{if($4){printf("%d", $4)}} END {if (!NR) print "0"}' > genome_size_output
+          grep "Estimated coverage:" mash-output.txt | \
+            awk '{if($3){printf("%d", $3)}} END {if (!NR) print "0"}' > coverage_output
+          rm -rf test.msh
+          rm -rf mash-output.txt
+        fi
+        
+        estimated_genome_size=`head -n1 genome_size_output`
+        estimated_coverage=`head -n1 coverage_output`
+
+        # if below/above min/max genome size, set pass/fail flag
+        if [ "${estimated_genome_size}" -ge "~{max_genome_size}" ] ; then
+          flag="FAIL; the genome size is estimated to be larger than the maximum of ~{max_genome_size} bps"
+        elif [ "${estimated_genome_size}" -le "~{min_genome_size}" ] ; then
+          flag="FAIL; the genome size is estimated to be smaller than the minimum of ~{min_genome_size} bps"
+        else
+          flag="PASS"   
+          if [ "${estimated_coverage}" -le "~{min_coverage}" ] ; then
+            flag="FAIL; the estimated coverage is less than the minimum of ~{min_coverage}x"
+          else
+            flag="PASS"
+          fi    
+        fi    
+
+    
+      fi # third and fourth check close
+
+    fi # closes if skip_screen == "False" check
+    echo $flag | tee FLAG
   >>>
-  # was this done before or after?
   output {
-    String pass_screen = read_string("FLAG")
+    # do something fancy to only output one variable
+    String read_screen = read_string("FLAG")
   }
   runtime { ### NOT SURE
-    docker: ""
+    docker: "quay.io/bactopia/gather_samples:2.0.2"
     memory: "2 GB"
     cpu: 2
     disks: "local-disk 100 SSD"
     preemptible: 0
     maxRetries: 3
-  } 
-}
-
-task check_proportion {
-  input {
-    File read1
-    File read2
-    Float? min_proportion = 0.5
-  }
-  command <<<
-  echo "test"
-  >>>
-  # i can't remember what this was used for
-  output {
-    String pass_screen = read_string("FLAG")
-  }
-  runtime { ### NOT SURE
-    docker: ""
-    memory: "2 GB"
-    cpu: 2
-    disks: "local-disk 100 SSD"
-    preemptible: 0
-    maxRetries: 3
   }
 }
 
+# proportion : 100 in R1 20 in R2, R2 needs to be at least 50% of R1 and/or vice versa

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -5,6 +5,7 @@ import "wf_merlin_magic.wdl" as merlin_magic
 import "../tasks/assembly/task_shovill.wdl" as shovill
 import "../tasks/quality_control/task_quast.wdl" as quast
 import "../tasks/quality_control/task_cg_pipeline.wdl" as cg_pipeline
+import "../tasks/quality_control/task_screen.wdl" as screen
 import "../tasks/taxon_id/task_gambit.wdl" as gambit
 import "../tasks/gene_typing/task_abricate.wdl" as abricate
 import "../tasks/species_typing/task_serotypefinder.wdl" as serotypefinder
@@ -25,128 +26,142 @@ workflow theiaprok_illumina_pe {
     String terra_project="NA"
     String terra_workspace="NA"
   }
-  call read_qc.read_QC_trim {
-    input:
-      samplename = samplename,
-      read1_raw = read1_raw,
-      read2_raw = read2_raw
-  }
-  call shovill.shovill_pe {
-    input:
-      samplename = samplename,
-      read1_cleaned = read_QC_trim.read1_clean,
-      read2_cleaned = read_QC_trim.read2_clean
-  }
-  call quast.quast {
-    input:
-      assembly = shovill_pe.assembly_fasta,
-      samplename = samplename
-  }
-  call cg_pipeline.cg_pipeline {
-    input:
-      read1 = read1_raw,
-      read2 = read2_raw,
-      samplename = samplename,
-      genome_length = quast.genome_length
-  }
-  call gambit.gambit {
-    input:
-      assembly = shovill_pe.assembly_fasta,
-      samplename = samplename
-  }
-  call abricate.abricate as abricate_amr {
-    input:
-      assembly = shovill_pe.assembly_fasta,
-      samplename = samplename,
-      database = "ncbi"
-  }
-  call merlin_magic.merlin_magic {
-    input:
-      merlin_tag = gambit.merlin_tag,
-      assembly = shovill_pe.assembly_fasta,
-      samplename = samplename,
-      read1 = read_QC_trim.read1_clean,
-      read2 = read_QC_trim.read2_clean
-  }
   call versioning.version_capture{
     input:
   }
-  if(defined(taxon_tables)) {
-    call terra_tools.export_taxon_tables {
+  call screen.check_reads as raw_check_reads {
+    input:
+      read1 = read1_raw,
+      read2 = read2_raw
+  }
+  if (raw_check_reads.read_screen=="PASS") {
+    call read_qc.read_QC_trim {
       input:
-        terra_project = terra_project,
-        terra_workspace = terra_workspace,
-        sample_taxon = gambit.gambit_predicted_taxon,
-        taxon_tables = taxon_tables,
         samplename = samplename,
-        read1 = read1_raw,
-        read2 = read2_raw,
-        run_id = run_id,
-        theiaprok_illumina_pe_version = version_capture.phbg_version,
-        theiaprok_illumina_pe_analysis_date = version_capture.date,
-        seq_platform = seq_method,
-        num_reads_raw1 = read_QC_trim.fastq_scan_raw1,
-        num_reads_raw2 = read_QC_trim.fastq_scan_raw2,
-        num_reads_raw_pairs = read_QC_trim.fastq_scan_raw_pairs,
-        fastq_scan_version = read_QC_trim.fastq_scan_version,
-        num_reads_clean1 = read_QC_trim.fastq_scan_clean1,
-        num_reads_clean2 = read_QC_trim.fastq_scan_clean2,
-        num_reads_clean_pairs = read_QC_trim.fastq_scan_clean_pairs,
-        trimmomatic_version = read_QC_trim.trimmomatic_version,
-        bbduk_docker = read_QC_trim.bbduk_docker,
-        r1_mean_q = cg_pipeline.r1_mean_q,
-        r2_mean_q = cg_pipeline.r2_mean_q,
-        assembly_fasta = shovill_pe.assembly_fasta,
-        contigs_gfa = shovill_pe.contigs_gfa,
-        shovill_pe_version = shovill_pe.shovill_version,
-        quast_report = quast.quast_report,
-        quast_version = quast.version,
-        genome_length = quast.genome_length,
-        number_contigs = quast.number_contigs,
-        cg_pipeline_report = cg_pipeline.cg_pipeline_report,
-        cg_pipeline_docker = cg_pipeline.cg_pipeline_docker,
-        est_coverage = cg_pipeline.est_coverage,
-        gambit_report = gambit.gambit_report_file,
-        gambit_predicted_taxon = gambit.gambit_predicted_taxon,
-        gambit_predicted_taxon_rank = gambit.gambit_predicted_taxon_rank,
-        gambit_version = gambit.gambit_version,
-        gambit_db_version = gambit.gambit_db_version,
-        gambit_docker = gambit.gambit_docker,
-        abricate_amr_results = abricate_amr.abricate_results,
-        abricate_amr_database = abricate_amr.abricate_database,
-        abricate_amr_version = abricate_amr.abricate_version,
-        serotypefinder_report = merlin_magic.serotypefinder_report,
-        serotypefinder_docker = merlin_magic.serotypefinder_docker,
-        serotypefinder_serotype = merlin_magic.serotypefinder_serotype,
-        ectyper_results = merlin_magic.ectyper_results,
-        ectyper_version = merlin_magic.ectyper_version,
-        ectyper_predicted_serotype = merlin_magic.ectyper_predicted_serotype,
-        lissero_results = merlin_magic.lissero_results,
-        lissero_version = merlin_magic.lissero_version,
-        sistr_results = merlin_magic.sistr_results,
-        sistr_allele_json = merlin_magic.sistr_allele_json,
-        sister_allele_fasta = merlin_magic.sistr_allele_fasta,
-        sistr_cgmlst = merlin_magic.sistr_cgmlst,
-        sistr_version = merlin_magic.sistr_version,
-        sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype,
-        seqsero2_report = merlin_magic.seqsero2_report,
-        seqsero2_version = merlin_magic.seqsero2_version,
-        seqsero2_predicted_antigenic_profile = merlin_magic.seqsero2_predicted_antigenic_profile,
-        seqsero2_predicted_serotype = merlin_magic.seqsero2_predicted_serotype,
-        seqsero2_predicted_contamination = merlin_magic.seqsero2_predicted_contamination,
-        kleborate_output_file = merlin_magic.kleborate_output_file,
-        kleborate_version = merlin_magic.kleborate_version,
-        kleborate_key_resistance_genes = merlin_magic.kleborate_key_resistance_genes,
-        kleborate_genomic_resistance_mutations = merlin_magic.kleborate_genomic_resistance_mutations,
-        kleborate_mlst_sequence_type = merlin_magic.kleborate_mlst_sequence_type,
-        tbprofiler_output_file = merlin_magic.tbprofiler_output_file,
-        tbprofiler_output_bam = merlin_magic.tbprofiler_output_bam,
-        tbprofiler_output_bai = merlin_magic.tbprofiler_output_bai,
-        tbprofiler_version = merlin_magic.tbprofiler_version,
-        tbprofiler_main_lineage = merlin_magic.tbprofiler_main_lineage,
-        tbprofiler_sub_lineage = merlin_magic.tbprofiler_sub_lineage,
-        tbprofiler_dr_type = merlin_magic.tbprofiler_dr_type,
-        tbprofiler_resistance_genes = merlin_magic.tbprofiler_resistance_genes
+        read1_raw = read1_raw,
+        read2_raw = read2_raw
+    }
+    call screen.check_reads as clean_check_reads {
+      input:
+        read1 = read_QC_trim.read1_clean,
+        read2 = read_QC_trim.read2_clean
+    }
+    if (clean_check_reads.read_screen=="PASS") {
+      call shovill.shovill_pe {
+        input:
+          samplename = samplename,
+          read1_cleaned = read_QC_trim.read1_clean,
+          read2_cleaned = read_QC_trim.read2_clean
+      }
+      call quast.quast {
+        input:
+          assembly = shovill_pe.assembly_fasta,
+          samplename = samplename
+      }
+      call cg_pipeline.cg_pipeline {
+        input:
+          read1 = read1_raw,
+          read2 = read2_raw,
+          samplename = samplename,
+          genome_length = quast.genome_length
+      }
+      call gambit.gambit {
+        input:
+          assembly = shovill_pe.assembly_fasta,
+          samplename = samplename
+      }
+      call abricate.abricate as abricate_amr {
+        input:
+          assembly = shovill_pe.assembly_fasta,
+          samplename = samplename,
+          database = "ncbi"
+      }
+      call merlin_magic.merlin_magic {
+        input:
+          merlin_tag = gambit.merlin_tag,
+          assembly = shovill_pe.assembly_fasta,
+          samplename = samplename,
+          read1 = read_QC_trim.read1_clean,
+          read2 = read_QC_trim.read2_clean
+      }
+      if(defined(taxon_tables)) {
+        call terra_tools.export_taxon_tables {
+          input:
+            terra_project = terra_project,
+            terra_workspace = terra_workspace,
+            sample_taxon = gambit.gambit_predicted_taxon,
+            taxon_tables = taxon_tables,
+            samplename = samplename,
+            read1 = read1_raw,
+            read2 = read2_raw,
+            run_id = run_id,
+            theiaprok_illumina_pe_version = version_capture.phbg_version,
+            theiaprok_illumina_pe_analysis_date = version_capture.date,
+            seq_platform = seq_method,
+            num_reads_raw1 = read_QC_trim.fastq_scan_raw1,
+            num_reads_raw2 = read_QC_trim.fastq_scan_raw2,
+            num_reads_raw_pairs = read_QC_trim.fastq_scan_raw_pairs,
+            fastq_scan_version = read_QC_trim.fastq_scan_version,
+            num_reads_clean1 = read_QC_trim.fastq_scan_clean1,
+            num_reads_clean2 = read_QC_trim.fastq_scan_clean2,
+            num_reads_clean_pairs = read_QC_trim.fastq_scan_clean_pairs,
+            trimmomatic_version = read_QC_trim.trimmomatic_version,
+            bbduk_docker = read_QC_trim.bbduk_docker,
+            r1_mean_q = cg_pipeline.r1_mean_q,
+            r2_mean_q = cg_pipeline.r2_mean_q,
+            assembly_fasta = shovill_pe.assembly_fasta,
+            contigs_gfa = shovill_pe.contigs_gfa,
+            shovill_pe_version = shovill_pe.shovill_version,
+            quast_report = quast.quast_report,
+            quast_version = quast.version,
+            genome_length = quast.genome_length,
+            number_contigs = quast.number_contigs,
+            cg_pipeline_report = cg_pipeline.cg_pipeline_report,
+            cg_pipeline_docker = cg_pipeline.cg_pipeline_docker,
+            est_coverage = cg_pipeline.est_coverage,
+            gambit_report = gambit.gambit_report_file,
+            gambit_predicted_taxon = gambit.gambit_predicted_taxon,
+            gambit_predicted_taxon_rank = gambit.gambit_predicted_taxon_rank,
+            gambit_version = gambit.gambit_version,
+            gambit_db_version = gambit.gambit_db_version,
+            gambit_docker = gambit.gambit_docker,
+            abricate_amr_results = abricate_amr.abricate_results,
+            abricate_amr_database = abricate_amr.abricate_database,
+            abricate_amr_version = abricate_amr.abricate_version,
+            serotypefinder_report = merlin_magic.serotypefinder_report,
+            serotypefinder_docker = merlin_magic.serotypefinder_docker,
+            serotypefinder_serotype = merlin_magic.serotypefinder_serotype,
+            ectyper_results = merlin_magic.ectyper_results,
+            ectyper_version = merlin_magic.ectyper_version,
+            ectyper_predicted_serotype = merlin_magic.ectyper_predicted_serotype,
+            lissero_results = merlin_magic.lissero_results,
+            lissero_version = merlin_magic.lissero_version,
+            sistr_results = merlin_magic.sistr_results,
+            sistr_allele_json = merlin_magic.sistr_allele_json,
+            sister_allele_fasta = merlin_magic.sistr_allele_fasta,
+            sistr_cgmlst = merlin_magic.sistr_cgmlst,
+            sistr_version = merlin_magic.sistr_version,
+            sistr_predicted_serotype = merlin_magic.sistr_predicted_serotype,
+            seqsero2_report = merlin_magic.seqsero2_report,
+            seqsero2_version = merlin_magic.seqsero2_version,
+            seqsero2_predicted_antigenic_profile = merlin_magic.seqsero2_predicted_antigenic_profile,
+            seqsero2_predicted_serotype = merlin_magic.seqsero2_predicted_serotype,
+            seqsero2_predicted_contamination = merlin_magic.seqsero2_predicted_contamination,
+            kleborate_output_file = merlin_magic.kleborate_output_file,
+            kleborate_version = merlin_magic.kleborate_version,
+            kleborate_key_resistance_genes = merlin_magic.kleborate_key_resistance_genes,
+            kleborate_genomic_resistance_mutations = merlin_magic.kleborate_genomic_resistance_mutations,
+            kleborate_mlst_sequence_type = merlin_magic.kleborate_mlst_sequence_type,
+            tbprofiler_output_file = merlin_magic.tbprofiler_output_file,
+            tbprofiler_output_bam = merlin_magic.tbprofiler_output_bam,
+            tbprofiler_output_bai = merlin_magic.tbprofiler_output_bai,
+            tbprofiler_version = merlin_magic.tbprofiler_version,
+            tbprofiler_main_lineage = merlin_magic.tbprofiler_main_lineage,
+            tbprofiler_sub_lineage = merlin_magic.tbprofiler_sub_lineage,
+            tbprofiler_dr_type = merlin_magic.tbprofiler_dr_type,
+            tbprofiler_resistance_genes = merlin_magic.tbprofiler_resistance_genes
+        }
+      }
     }
   }
   output {
@@ -155,41 +170,44 @@ workflow theiaprok_illumina_pe {
     String theiaprok_illumina_pe_analysis_date = version_capture.date
     #Read Metadata
     String seq_platform = seq_method
+    #Sample Screening
+    String raw_read_screen = raw_check_reads.read_screen
+    String? clean_read_screen = clean_check_reads.read_screen
     #Read QC
-    Int num_reads_raw1 = read_QC_trim.fastq_scan_raw1
-    Int num_reads_raw2 = read_QC_trim.fastq_scan_raw2
-    String num_reads_raw_pairs = read_QC_trim.fastq_scan_raw_pairs
-    String fastq_scan_version = read_QC_trim.fastq_scan_version
-    Int num_reads_clean1 = read_QC_trim.fastq_scan_clean1
-    Int num_reads_clean2 = read_QC_trim.fastq_scan_clean2
-    String num_reads_clean_pairs = read_QC_trim.fastq_scan_clean_pairs
-    String trimmomatic_version = read_QC_trim.trimmomatic_version
-    String bbduk_docker = read_QC_trim.bbduk_docker
-    Float r1_mean_q = cg_pipeline.r1_mean_q
+    Int? num_reads_raw1 = read_QC_trim.fastq_scan_raw1
+    Int? num_reads_raw2 = read_QC_trim.fastq_scan_raw2
+    String? num_reads_raw_pairs = read_QC_trim.fastq_scan_raw_pairs
+    String? fastq_scan_version = read_QC_trim.fastq_scan_version
+    Int? num_reads_clean1 = read_QC_trim.fastq_scan_clean1
+    Int? num_reads_clean2 = read_QC_trim.fastq_scan_clean2
+    String? num_reads_clean_pairs = read_QC_trim.fastq_scan_clean_pairs
+    String? trimmomatic_version = read_QC_trim.trimmomatic_version
+    String? bbduk_docker = read_QC_trim.bbduk_docker
+    Float? r1_mean_q = cg_pipeline.r1_mean_q
     Float? r2_mean_q = cg_pipeline.r2_mean_q
     #Assembly and Assembly QC
-    File assembly_fasta = shovill_pe.assembly_fasta
-    File contigs_gfa = shovill_pe.contigs_gfa
-    String shovill_pe_version = shovill_pe.shovill_version
-    File quast_report = quast.quast_report
-    String quast_version = quast.version
-    Int genome_length = quast.genome_length
-    Int number_contigs = quast.number_contigs
-    File cg_pipeline_report = cg_pipeline.cg_pipeline_report
-    String cg_pipeline_docker = cg_pipeline.cg_pipeline_docker
-    Float est_coverage = cg_pipeline.est_coverage
+    File? assembly_fasta = shovill_pe.assembly_fasta
+    File? contigs_gfa = shovill_pe.contigs_gfa
+    String? shovill_pe_version = shovill_pe.shovill_version
+    File? quast_report = quast.quast_report
+    String? quast_version = quast.version
+    Int? genome_length = quast.genome_length
+    Int? number_contigs = quast.number_contigs
+    File? cg_pipeline_report = cg_pipeline.cg_pipeline_report
+    String? cg_pipeline_docker = cg_pipeline.cg_pipeline_docker
+    Float? est_coverage = cg_pipeline.est_coverage
     #Taxon ID
-    File gambit_report = gambit.gambit_report_file
-    File gabmit_closest_genomes = gambit.gambit_closest_genomes_file
-    String gambit_predicted_taxon = gambit.gambit_predicted_taxon
-    String gambit_predicted_taxon_rank = gambit.gambit_predicted_taxon_rank
-    String gambit_version = gambit.gambit_version
-    String gambit_db_version = gambit.gambit_db_version
-    String gambit_docker = gambit.gambit_docker
+    File? gambit_report = gambit.gambit_report_file
+    File? gambit_closest_genomes = gambit.gambit_closest_genomes_file
+    String? gambit_predicted_taxon = gambit.gambit_predicted_taxon
+    String? gambit_predicted_taxon_rank = gambit.gambit_predicted_taxon_rank
+    String? gambit_version = gambit.gambit_version
+    String? gambit_db_version = gambit.gambit_db_version
+    String? gambit_docker = gambit.gambit_docker
     #AMR Screening
-    File abricate_amr_results = abricate_amr.abricate_results
-    String abricate_amr_database = abricate_amr.abricate_database
-    String abricate_amr_version = abricate_amr.abricate_version
+    File? abricate_amr_results = abricate_amr.abricate_results
+    String? abricate_amr_database = abricate_amr.abricate_database
+    String? abricate_amr_version = abricate_amr.abricate_version
     # Ecoli Typing
     File? serotypefinder_report = merlin_magic.serotypefinder_report
     String? serotypefinder_docker = merlin_magic.serotypefinder_docker


### PR DESCRIPTION
This PR adds the `task_screen.wdl` task file that performs basic screening of input reads before and after general read QC. The task has been added to `wf_theiaprok_illumina_pe.wdl` and a few tasks within it have been reorganized (e.g., placed within if statements) to accommodate the new screening.