### PR TITLE
Mash estimated genome size for cg-pipe

### DIFF
--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -69,7 +69,7 @@ workflow theiaprok_illumina_pe {
           read1 = read1_raw,
           read2 = read2_raw,
           samplename = samplename,
-          genome_length = quast.genome_length
+          genome_length = clean_check_reads.est_genome_length
       }
       call gambit.gambit {
         input:


### PR DESCRIPTION
This PR replaces the quast assembly length with the Mash estimated genome size for the cg-pipeline read coverage calculations in the TheiaProk_Illumina_PE workflow