### PR TITLE
Generate kSNP3 VCF file

### DIFF
--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -33,6 +33,12 @@ task ksnp3 {
   # run ksnp3 on input assemblies
   kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core -vcf
   
+  echo "in out: "
+  ls ksnp3
+  
+  echo "find vcf file: "
+  find / -name *vcfss
+  
   # rename ksnp3 outputs with cluster name 
   mv ksnp3/core_SNPs_matrix.fasta ~{cluster_name}_core_SNPs_matrix.fasta
   mv ksnp3/tree.core.tre ~{cluster_name}_core.tree

--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -27,17 +27,10 @@ task ksnp3 {
   for index in ${!assembly_array[@]}; do
     assembly=${assembly_array[$index]}
     samplename=${samplename_array[$index]}
-    
     echo -e "${assembly}\t${samplename}" >> ksnp3_input.tsv
   done
   # run ksnp3 on input assemblies
   kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core -vcf
-  
-  echo "in out: "
-  ls ksnp3
-  
-  echo "find vcf file: "
-  find / -name *vcfss
   
   # rename ksnp3 outputs with cluster name 
   mv ksnp3/core_SNPs_matrix.fasta ~{cluster_name}_core_SNPs_matrix.fasta

--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -42,13 +42,13 @@ task ksnp3 {
   # rename ksnp3 outputs with cluster name 
   mv ksnp3/core_SNPs_matrix.fasta ~{cluster_name}_core_SNPs_matrix.fasta
   mv ksnp3/tree.core.tre ~{cluster_name}_core.tree
-  mv ksnp3/VCF.*.vcf ~{cluster_name}_reference.vcf
+  mv ksnp3/VCF.*.vcf ~{cluster_name}_core.vcf
 
   >>>
   output {
     File ksnp3_matrix = "${cluster_name}_core_SNPs_matrix.fasta"
     File ksnp3_tree = "${cluster_name}_core.tree"
-    File ksnp3_vcf = "${cluster_name}_core.tree"
+    File ksnp3_vcf = "${cluster_name}_core.vcf"
     String ksnp3_docker_image = docker_image
   }
   runtime {

--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -31,16 +31,18 @@ task ksnp3 {
     echo -e "${assembly}\t${samplename}" >> ksnp3_input.tsv
   done
   # run ksnp3 on input assemblies
-  kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core 
+  kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core -vcf
   
   # rename ksnp3 outputs with cluster name 
   mv ksnp3/core_SNPs_matrix.fasta ~{cluster_name}_core_SNPs_matrix.fasta
   mv ksnp3/tree.core.tre ~{cluster_name}_core.tree
+  mv ksnp3/VCF.reference_genome.vcf ~{cluster_name}_reference.vcf
 
   >>>
   output {
     File ksnp3_matrix = "${cluster_name}_core_SNPs_matrix.fasta"
     File ksnp3_tree = "${cluster_name}_core.tree"
+    File ksnp3_vcf = "${cluster_name}_core.tree"
     String ksnp3_docker_image = docker_image
   }
   runtime {

--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -42,7 +42,7 @@ task ksnp3 {
   # rename ksnp3 outputs with cluster name 
   mv ksnp3/core_SNPs_matrix.fasta ~{cluster_name}_core_SNPs_matrix.fasta
   mv ksnp3/tree.core.tre ~{cluster_name}_core.tree
-  mv ksnp3/VCF.reference_genome.vcf ~{cluster_name}_reference.vcf
+  mv ksnp3/VCF.*.vcf ~{cluster_name}_reference.vcf
 
   >>>
   output {

--- a/workflows/wf_ksnp3.wdl
+++ b/workflows/wf_ksnp3.wdl
@@ -5,32 +5,32 @@ import "../tasks/phylogenetic_inference/task_snp_dists.wdl" as snp_dists
 import "../tasks/task_versioning.wdl" as versioning
 
 workflow ksnp3 {
-	input {
-		Array[File] assembly_fasta
+  input {
+    Array[File] assembly_fasta
     Array[String] samplename
     String cluster_name
-	}
-	call ksnp3.ksnp3 as ksnp3_task {
-		input:
-			assembly_fasta = assembly_fasta,
+  }
+  call ksnp3.ksnp3 as ksnp3_task {
+    input:
+      assembly_fasta = assembly_fasta,
       samplename = samplename,
       cluster_name = cluster_name
-	}
+  }
   call snp_dists.snp_dists {
     input:
       cluster_name = cluster_name,
       alignment = ksnp3_task.ksnp3_matrix
   }
-	call versioning.version_capture{
+  call versioning.version_capture{
     input:
   }
   output {
     String ksnp3_wf_version = version_capture.phbg_version
     String knsp3_wf_analysis_date = version_capture.date
-		
+
     File ksnp3_snp_matrix = snp_dists.snp_matrix
     File ksnp3_tree = ksnp3_task.ksnp3_tree
-		File ksnp3_vcf = ksnp3_task.ksnp3_vcf
+    File ksnp3_vcf = ksnp3_task.ksnp3_vcf
     String ksnp3_docker = ksnp3_task.ksnp3_docker_image
-    }
+  }
 }

--- a/workflows/wf_ksnp3.wdl
+++ b/workflows/wf_ksnp3.wdl
@@ -1,6 +1,7 @@
 version 1.0
 
-import "../tasks/task_phylo.wdl" as phylo
+import "../tasks/phylogenetic_inference/task_ksnp3.wdl" as ksnp3
+import "../tasks/phylogenetic_inference/task_snp_dists.wdl" as snp_dists
 import "../tasks/task_versioning.wdl" as versioning
 
 workflow ksnp3 {
@@ -9,13 +10,13 @@ workflow ksnp3 {
     Array[String] samplename
     String cluster_name
 	}
-	call phylo.ksnp3 as ksnp3_task {
+	call ksnp3.ksnp3 as ksnp3_task {
 		input:
 			assembly_fasta = assembly_fasta,
       samplename = samplename,
       cluster_name = cluster_name
 	}
-  call phylo.snp_dists {
+  call snp_dists.snp_dists {
     input:
       cluster_name = cluster_name,
       alignment = ksnp3_task.ksnp3_matrix
@@ -29,6 +30,7 @@ workflow ksnp3 {
 		
     File ksnp3_snp_matrix = snp_dists.snp_matrix
     File ksnp3_tree = ksnp3_task.ksnp3_tree
+		File ksnp3_vcf = ksnp3_task.ksnp3_vcf
     String ksnp3_docker = ksnp3_task.ksnp3_docker_image
     }
 }


### PR DESCRIPTION
This PR adds the `-vcf` flag to the `ksnpe3` task in order to generate a VCF file; a new output attribute is created to ensure this file is captured by both the ksnp3 task and workflow. 