### PR TITLE
Legsta fix SBT output value for samples with no SBT predicted

### DIFF
--- a/tasks/species_typing/task_legsta.wdl
+++ b/tasks/species_typing/task_legsta.wdl
@@ -20,10 +20,10 @@ task legsta {
       SBT="No SBT predicted"
     else
       SBT="ST$(tail -n 1 ~{samplename}.tsv | cut -f 2)"
-        if [ "$SBT" == "-" ]; then
+        if [ "$SBT" == "ST-" ]; then
           SBT="No SBT predicted"
         else
-          if [ "$SBT" == "" ]; then
+          if [ "$SBT" == "ST" ]; then
             SBT="No SBT predicted"
           fi
         fi  


### PR DESCRIPTION
Samples where SBT is not predicted are currently indicated by "ST-" in the legsta_predicted_sbt column. This fix changes this output to read "No SBT predicted", as intended.

- edits line in task_legsta.wdl