### PR TITLE
Add RASUSA Task and Workflow File

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -55,3 +55,8 @@ workflows:
    primaryDescriptorPath: /workflows/wf_kraken2_se.wdl
    testParameterFiles:
     - empty.json
+ - name: RASUSA
+   subclass: WDL
+   primaryDescriptorPath: /workflows/wf_rasusa.wdl
+   testParameterFiles:
+    - empty.json

--- a/tasks/utilities/task_rasusa.wdl
+++ b/tasks/utilities/task_rasusa.wdl
@@ -28,7 +28,7 @@ task rasusa {
     else
       OUTPUT_FILES="~{samplename}_R1.fastq.gz ~{samplename}_R2.fastq.gz"
     fi
-      
+     
     rasusa \
       -i ~{read1} ~{read2} \
       --coverage "~{coverage}" \
@@ -40,7 +40,7 @@ task rasusa {
   >>>
   output {
     File read1_subsampled = "~{samplename}_R1.fastq.gz"
-    File? read2_subsampled = "~{samplename}_R1.fastq.gz"
+    File? read2_subsampled = "~{samplename}_R2.fastq.gz"
     String rasusa_version = read_string("VERSION")
   }
   runtime {

--- a/tasks/utilities/task_rasusa.wdl
+++ b/tasks/utilities/task_rasusa.wdl
@@ -10,7 +10,6 @@ task rasusa {
     String samplename
     String docker = "staphb/rasusa:0.6.0"
     Int cpu = 4
-
     # RASUA Parameters
     #  --bases [STRING] Explicitly set the number of bases required e.g., 4.3kb, 7Tb, 9000, 4.1MB. If this option is given, --coverage and --genome-size are ignored
     #  --coverage [FLOAT] The desired coverage to sub-sample the reads to. If --bases is not provided, this option and --genome-size are required
@@ -34,7 +33,7 @@ task rasusa {
       --coverage "~{coverage}" \
       --genome-size "~{genome_size}" \
       ~{'--seed ' + seed} \
-      ~{'--basses ' + bases} \
+      ~{'--bases ' + bases} \
       -o ${OUTPUT_FILES}
 
   >>>

--- a/tasks/utilities/task_rasusa.wdl
+++ b/tasks/utilities/task_rasusa.wdl
@@ -8,38 +8,49 @@ task rasusa {
     File read1
     File? read2
     String samplename
-    String docker = "staphb/rasusa:0.6.0"
+    String docker = "staphb/rasusa:0.7.0"
     Int cpu = 4
     # RASUA Parameters
     #  --bases [STRING] Explicitly set the number of bases required e.g., 4.3kb, 7Tb, 9000, 4.1MB. If this option is given, --coverage and --genome-size are ignored
     #  --coverage [FLOAT] The desired coverage to sub-sample the reads to. If --bases is not provided, this option and --genome-size are required
     #  --genome_size [STRING] Genome size to calculate coverage with respect to. e.g., 4.3kb, 7Tb, 9000, 4.1MB
-    # --seed [INTERGER] Random seed to use
+    #  --seed [INTERGER] Random seed to use
+    #  --frac [FLOAT] Subsample to a fraction of the reads - e.g., 0.5 samples half the reads
+    #  --num [INTEGER] Subsample to a specific number of reads
     String? bases
     Float coverage 
     String genome_size
     Int? seed
+    Float? frac
+    Int? num 
   }
   command <<<
     rasusa --version | tee VERSION
+    # set single-end or paired-end outputs
     if [ -z "~{read2}" ]; then
-      OUTPUT_FILES="~{samplename}_R1.fastq.gz"
+      OUTPUT_FILES="~{samplename}_subsampled_R1.fastq.gz"
     else
-      OUTPUT_FILES="~{samplename}_R1.fastq.gz ~{samplename}_R2.fastq.gz"
+      OUTPUT_FILES="~{samplename}_subsampled_R1.fastq.gz ~{samplename}_subsampled_R2.fastq.gz"
     fi
-     
+    # ignore coverage values if frac input provided
+    if [ -z "~{frac}" ]; then
+      COVERAGE="--coverage ~{coverage} --genome-size ~{genome_size}"
+    else
+      COVERAGE=""
+    fi
+    # run rasusa
     rasusa \
       -i ~{read1} ~{read2} \
-      --coverage "~{coverage}" \
-      --genome-size "~{genome_size}" \
+      ${COVERAGE} \
       ~{'--seed ' + seed} \
       ~{'--bases ' + bases} \
+      ~{'--frac ' + frac} \
+      ~{'--num ' + num} \
       -o ${OUTPUT_FILES}
-
   >>>
   output {
-    File read1_subsampled = "~{samplename}_R1.fastq.gz"
-    File? read2_subsampled = "~{samplename}_R2.fastq.gz"
+    File read1_subsampled = "~{samplename}_subsampled_R1.fastq.gz"
+    File? read2_subsampled = "~{samplename}_subsampled_R2.fastq.gz"
     String rasusa_version = read_string("VERSION")
   }
   runtime {

--- a/workflows/wf_rasusa.wdl
+++ b/workflows/wf_rasusa.wdl
@@ -1,0 +1,33 @@
+version 1.0
+
+import "../tasks/utilities/task_rasusa.wdl" as rasusa
+import "../tasks/task_versioning.wdl" as versioning
+
+workflow rasusa_workflow {
+  input {
+    File read1
+    File? read2
+    String samplename
+    Float coverage
+    String genome_size
+  }
+  call rasusa.rasusa as rasusa_task {
+    input:
+      read1 = read1,
+      read2 = read2,
+      samplename = samplename,
+      genome_size = genome_size,
+      coverage = coverage
+  }
+  call versioning.version_capture{
+    input:
+  }
+  output {
+    String rasusa_wf_version = version_capture.phbg_version
+    String rasusa_wf_analysis_date = version_capture.date
+
+    String rasusa_version = rasusa_task.rasusa_version
+    File read1_subsampled = rasusa_task.read1_subsampled
+    File? read2_subsampled = rasusa_task.read2_subsampled
+  }
+}


### PR DESCRIPTION
This PR adds a RAUSA task ([tasks/utilities/task_rasusa.wdl](https://github.com/theiagen/public_health_bacterial_genomics/compare/kgl-rasusa-dev?expand=1#diff-609e414bd5d8ca15fa85d9b6a9a7567d3b618255a4eaa44b06e3ff8b66087d41)) and workflow ([tasks/utilities/task_rasusa.wdl](https://github.com/theiagen/public_health_bacterial_genomics/compare/kgl-rasusa-dev?expand=1#diff-609e414bd5d8ca15fa85d9b6a9a7567d3b618255a4eaa44b06e3ff8b66087d41)) to the repo.

The task file was written to ingest either single or paired-end read data iand generate subsampled outputs (`~{samplename}_R1.fastq.gz` and `~{samplename}_R2.fastq.gz` for forward and rev reads, respectively) and exposes all relevant rasusa params.

The `.dockstore.yml` file was updated to publish workflow on Dockstore.

*Note:* [RASUSA v0.7.0 ](https://github.com/mbhall88/rasusa/releases/tag/0.7.0) was recently released, but no current StaPH-B docker image for this resource. v0.7.0 includes some useful params that we may want to upgrade to once a StaPH-B docker image becomes available.  
