### PR TITLE
remove compression from alignment files

### DIFF
--- a/tasks/phylogenetic_inference/task_pirate.wdl
+++ b/tasks/phylogenetic_inference/task_pirate.wdl
@@ -34,9 +34,6 @@ task pirate {
   ~{'--pan-opt ' + panopt} \
   ~{'--threads ' + cpu} 
   
-  # compress files
-  gzip PIRATE/pangenome_alignment.fasta
-  gzip PIRATE/core_alignment.fasta
   # rename outputs with cluster name 
   mv PIRATE/PIRATE.pangenome_summary.txt PIRATE/~{cluster_name}_pangenome_summary.txt
   mv PIRATE/PIRATE.log PIRATE/~{cluster_name}.log
@@ -45,9 +42,9 @@ task pirate {
   mv PIRATE/binary_presence_absence.fasta PIRATE/~{cluster_name}_binary_presence_absence.fasta
   mv PIRATE/binary_presence_absence.nwk PIRATE/~{cluster_name}_binary_presence_absence.nwk
   mv PIRATE/pangenome.gfa PIRATE/~{cluster_name}_pangenome.gfa
-  mv PIRATE/pangenome_alignment.fasta.gz PIRATE/~{cluster_name}_pangenome_alignment.fasta.gz
+  mv PIRATE/pangenome_alignment.fasta PIRATE/~{cluster_name}_pangenome_alignment.fasta
   mv PIRATE/pangenome_alignment.gff PIRATE/~{cluster_name}_pangenome_alignment.gff
-  mv PIRATE/core_alignment.fasta.gz PIRATE/~{cluster_name}_core_alignment.fasta.gz
+  mv PIRATE/core_alignment.fasta PIRATE/~{cluster_name}_core_alignment.fasta
   mv PIRATE/core_alignment.gff PIRATE/~{cluster_name}_core_alignment.gff
 
   >>>
@@ -58,9 +55,9 @@ task pirate {
     File pirate_binary_fasta = "PIRATE/~{cluster_name}_binary_presence_absence.fasta"
     File pirate_binary_tree = "PIRATE/~{cluster_name}_binary_presence_absence.nwk"
     File pirate_pangenome_gfa = "PIRATE/~{cluster_name}_pangenome.gfa" 
-    File pirate_pangenome_alignment_fasta = "PIRATE/~{cluster_name}_pangenome_alignment.fasta.gz" 
+    File pirate_pangenome_alignment_fasta = "PIRATE/~{cluster_name}_pangenome_alignment.fasta" 
     File pirate_pangenome_alignment_gff = "PIRATE/~{cluster_name}_pangenome_alignment.gff" 
-    File pirate_core_alignment_fasta = "PIRATE/~{cluster_name}_core_alignment.fasta.gz" 
+    File pirate_core_alignment_fasta = "PIRATE/~{cluster_name}_core_alignment.fasta" 
     File pirate_core_alignment_gff = "PIRATE/~{cluster_name}_core_alignment.gff" 
     String pirate_docker_image = docker_image
   } 


### PR DESCRIPTION
This PR removes the compression step from the alignments outputted by pirate, which was interfering with downstream tree-building.