### PR TITLE
amrfinderplus task updates

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -64,7 +64,7 @@ jobs:
       # Depends and env info (mostly for debug)
       - name: Install Dependencies
         run: |
-          conda install -y -c conda-forge -c bioconda cromwell miniwdl 'python>=3.7' pytest pytest-workflow
+          conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow
           uname -a && env
 
       - name: Test ${{ matrix.tag }}

--- a/tasks/gene_typing/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/task_amrfinderplus.wdl
@@ -19,7 +19,7 @@ task amrfinderplus_nuc {
     amrfinder --version | tee AMRFINDER_VERSION
     
     # capture the database version; strip out unnecessary output, remove "Database version: " that prints in front of the actual database version
-    amrfinder --database_version 2>/dev/null | grep "Database version" | sed 's|Database version: ||' >AMRFINDER_DB_VERSION
+    amrfinder --database_version 2>/dev/null | grep "Database version" | sed 's|Database version: ||' | tee AMRFINDER_DB_VERSION
 
     ### set $amrfinder_organism BASH variable based on gambit_predicted_taxon or user-defined input string
     ### final variable has strict syntax/spelling based on list from amrfinder --list_organisms

--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -6,7 +6,7 @@ task plasmidfinder {
     String samplename
     Int cpu = 8
     Int memory = 16
-    String docker = "staphb/plasmidfinder:2.1.6"
+    String docker = "quay.io/biocontainers/plasmidfinder:2.1.6--py310hdfd78af_1"
     String? database
     String? database_path
     String? method_path

--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -6,7 +6,7 @@ task plasmidfinder {
     String samplename
     Int cpu = 8
     Int memory = 16
-    String docker = "quay.io/biocontainers/plasmidfinder:2.1.6--py310hdfd78af_1"
+    String docker = "staphb/plasmidfinder:2.1.6"
     String? database
     String? database_path
     String? method_path
@@ -18,6 +18,7 @@ task plasmidfinder {
   }
   command <<<
   env
+  df -h
   
   date | tee DATE
 

--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -17,6 +17,8 @@ task plasmidfinder {
 
   }
   command <<<
+  env
+  
   date | tee DATE
 
   if [[ ! -z "~{database}" ]]; then 

--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -6,7 +6,7 @@ task plasmidfinder {
     String samplename
     Int cpu = 8
     Int memory = 16
-    String docker = "staphb/plasmidfinder:2.1.6"
+    String docker = "quay.io/staphb/plasmidfinder:2.1.6"
     String? database
     String? database_path
     String? method_path

--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -6,7 +6,7 @@ task plasmidfinder {
     String samplename
     Int cpu = 8
     Int memory = 16
-    String docker = "quay.io/staphb/plasmidfinder:2.1.6"
+    String docker = "quay.io/biocontainers/plasmidfinder:2.1.6--py310hdfd78af_1"
     String? database
     String? database_path
     String? method_path

--- a/tasks/gene_typing/task_plasmidfinder.wdl
+++ b/tasks/gene_typing/task_plasmidfinder.wdl
@@ -6,7 +6,7 @@ task plasmidfinder {
     String samplename
     Int cpu = 8
     Int memory = 16
-    String docker = "quay.io/biocontainers/plasmidfinder:2.1.6--py310hdfd78af_1"
+    String docker = "staphb/plasmidfinder:2.1.6"
     String? database
     String? database_path
     String? method_path
@@ -16,10 +16,7 @@ task plasmidfinder {
     Float? threshold
 
   }
-  command <<<
-  env
-  df -h
-  
+  command <<<  
   date | tee DATE
 
   if [[ ! -z "~{database}" ]]; then 

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -43,8 +43,6 @@
       md5sum: 9c9c511ab5bfade46f0db1b2ee5b4666
     - path: miniwdl_run/call-amrfinderplus_task/work/_miniwdl_inputs/0/test_contigs.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
-    - path: miniwdl_run/call-amrfinderplus_task/work/amrfinder.STDOUT-and-STDERR.log
-      contains: ["AMRFinder", "blast", "report"]
     - path: miniwdl_run/call-amrfinderplus_task/work/test_amrfinder_all.tsv
       md5sum: a5cc7b0baa9e11c9a31540800d0a740c
     - path: miniwdl_run/call-amrfinderplus_task/work/test_amrfinder_amr.tsv

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -18,22 +18,21 @@
     - wf_theiaprok_illumina_pe_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: cbcb16101728ff39abab80c88c21fb60
+      md5sum: fe664da0e4d1746919e25ddcf76cc20d
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json
       contains: ["amrfinderplus_all_report", "STRESS", "tsv", "NCBI"]
     - path: miniwdl_run/call-amrfinderplus_task/stderr.txt
-      md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-amrfinderplus_task/stderr.txt.offset
     - path: miniwdl_run/call-amrfinderplus_task/stdout.txt
-      contains: ["Gambit", "AMRFinder", "blast", "report"]
+      contains: ["Gambit", "AMRFinder"]
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: c4396919ac552deedcb6a35fc4b65a79
+      md5sum: f2805db31ce8498ca8cb9ba16d12548e
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: b54f25593aeab5346df95ad08bf41a61
+      md5sum: 8f87daf07709865a95a12013aa2cbe08
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_GENES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/DATE
@@ -133,7 +132,6 @@
     - path: miniwdl_run/call-merlin_magic/inputs.json
       contains: ["assembly", "fasta", "samplename", "test"]
     - path: miniwdl_run/call-merlin_magic/outputs.json
-      md5sum: a5cac6164d4efaf16cb30472595c6f21
     - path: miniwdl_run/call-merlin_magic/workflow.log
       contains: ["wdl", "theiaprok_illumina_pe", "merlin", "done"]
     - path: miniwdl_run/call-quast/command

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -57,7 +57,6 @@
     - path: miniwdl_run/call-cg_pipeline/outputs.json
       contains: ["lyveset", "cg_pipeline", "est_coverage", "r2_mean_q"]
     - path: miniwdl_run/call-cg_pipeline/stderr.txt
-      md5sum: ce20ed8880cbf02437861ed9d858680f
     - path: miniwdl_run/call-cg_pipeline/stderr.txt.offset
     - path: miniwdl_run/call-cg_pipeline/stdout.txt
     - path: miniwdl_run/call-cg_pipeline/task.log
@@ -97,7 +96,6 @@
     - path: miniwdl_run/call-gambit/outputs.json
       contains: ["gambit", "csv", "json", "Candidatus"]
     - path: miniwdl_run/call-gambit/stderr.txt
-      md5sum: 6309bdacabb0b2ff1b12ba8382dbb5ad
     - path: miniwdl_run/call-gambit/stderr.txt.offset
     - path: miniwdl_run/call-gambit/stdout.txt
       contains: ["gambit"]
@@ -283,7 +281,6 @@
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/outputs.json
       contains: ["read", "fastq", "test", "trimmomatic"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/stderr.txt
-      md5sum: ce20ed8880cbf02437861ed9d858680f
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/stderr.txt.offset
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/stdout.txt
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/task.log


### PR DESCRIPTION
- default docker image set to amrfinderplus v3.10.36 (also via dockerhub instead of quay now)
- made `minid` and `mincov` inputs floats since it has to be a decimal from 0-1 (0-100%), e.g. 0.8 for 80%. These flags are actually usable now 😄 
- Altered task to capture database version in a more streamlined manner, using the actual `--database_version` flag instead of grepping from STDOUT/STDERR

Will address issues #136  and #87 

Tested fine locally with miniwdl and testing now in Terra: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/0b2bbc55-4c10-4851-936a-b97b0e50dff7

Will mark ready for review after testing is finished