### PR TITLE
kSNP3 task edit: changed file suffix from .tree to .nwk

### DIFF
--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -34,22 +34,21 @@ task ksnp3 {
   kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core -vcf
   
   # rename ksnp3 outputs with cluster name 
-  mv ksnp3/core_SNPs_matrix.fasta ksnp3/~{cluster_name}_core_SNPs_matrix.fasta
-  mv ksnp3/tree.core.tre ksnp3/~{cluster_name}_core.tree
-  mv ksnp3/VCF.*.vcf ksnp3/~{cluster_name}_core.vcf
-  mv ksnp3/SNPs_all_matrix.fasta ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta
-  mv ksnp3/tree.parsimony.tre ksnp3/~{cluster_name}_pan_parsiomony.tree
+  mv -v ksnp3/core_SNPs_matrix.fasta ksnp3/~{cluster_name}_core_SNPs_matrix.fasta
+  mv -v ksnp3/tree.core.tre ksnp3/~{cluster_name}_core.nwk
+  mv -v ksnp3/VCF.*.vcf ksnp3/~{cluster_name}_core.vcf
+  mv -v ksnp3/SNPs_all_matrix.fasta ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta
+  mv -v ksnp3/tree.parsimony.tre ksnp3/~{cluster_name}_pan_parsiomony.nwk
   
 
   >>>
   output {
     File ksnp3_core_matrix = "ksnp3/${cluster_name}_core_SNPs_matrix.fasta"
-    File ksnp3_core_tree = "ksnp3/${cluster_name}_core.tree"
+    File ksnp3_core_tree = "ksnp3/${cluster_name}_core.nwk"
     File ksnp3_core_vcf = "ksnp3/${cluster_name}_core.vcf"
     File ksnp3_pan_matrix = "ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta"
-    File ksnp3_pan_parsimony_tree = "ksnp3/~{cluster_name}_pan_parsiomony.tree"
+    File ksnp3_pan_parsimony_tree = "ksnp3/~{cluster_name}_pan_parsiomony.nwk"
     Array[File] ksnp_outs = glob("ksnp3/*")
-
     String ksnp3_docker_image = docker_image
   }
   runtime {


### PR DESCRIPTION
Relatively small change - output tree files end in `.nwk` now instead of `.tree`

Also made file-renaming `mv` commands verbose for logging purposes

Should be a more recognizable suffix to users

No need to edit the mashtree task, those tree files end in `.nwk` already

This will address issue #39 

Ran successfully in Terra here: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/957ed8bf-d5d6-4a11-96a7-490cd6922d36