### PR TITLE
update gambit task to v0.5.0 docker image

### DIFF
--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -4,7 +4,7 @@ task gambit {
   input {
     File assembly
     String samplename
-    String docker = "quay.io/staphb/gambit:0.4.0"
+    String docker = "quay.io/staphb/gambit:0.5.0"
     File? gambit_db_genomes
     File? gambit_db_signatures
   }

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -90,7 +90,7 @@
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/test_1.clean.fastq.gz
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/test_2.clean.fastq.gz
     - path: miniwdl_run/call-gambit/command
-      md5sum: 78c3082bc3d478f3d88e72c9ece17199
+      md5sum: 8408c43cf723efaf1a7d28332a5a2024
     - path: miniwdl_run/call-gambit/inputs.json
       contains: ["assembly", "fasta", "samplename", "test"]
     - path: miniwdl_run/call-gambit/outputs.json
@@ -104,9 +104,9 @@
     - path: miniwdl_run/call-gambit/work/CLOSEST_DISTANCE
     - path: miniwdl_run/call-gambit/work/DATE
     - path: miniwdl_run/call-gambit/work/GAMBIT_DB_VERSION
-      md5sum: 665bf196d268251de28d9e3de0a449f7
+      md5sum: 2276ab90b62c0219da0fac43d28b0512
     - path: miniwdl_run/call-gambit/work/GAMBIT_VERSION
-      md5sum: 6f7e3a39515a2c5db8a447b6dc4c88f2
+      md5sum: f04975119234de325222289d81748e6d
     - path: miniwdl_run/call-gambit/work/MERLIN_TAG
       md5sum: 08e9de24ab150d083240557cec091d53
     - path: miniwdl_run/call-gambit/work/NEXT_TAXON


### PR DESCRIPTION
This PR updates the gambit docker image used in the gambit task (https://github.com/theiagen/public_health_bacterial_genomics/blob/main/tasks/taxon_id/task_gambit.wdl) to quay.io/staphb/gambit:0.5.0.

Tested on 5 samples in Terra 