### PR TITLE
Add option to hide point mutations from AMRFinderPlus output & update default amrfinderplus docker image

### DIFF
--- a/tasks/gene_typing/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/task_amrfinderplus.wdl
@@ -13,6 +13,7 @@ task amrfinderplus_nuc {
     Boolean detailed_drug_class = false
     Int cpu = 4
     String docker = "staphb/ncbi-amrfinderplus:3.10.36"
+    Boolean hide_point_mutations = false
   }
   command <<<
     # logging info
@@ -89,6 +90,12 @@ task amrfinderplus_nuc {
         ~{'--threads ' + cpu} \
         ~{'--coverage_min ' + mincov} \
         ~{'--ident_min ' + minid}
+    fi
+
+    # remove mutations where Element subtype is "POINT"
+    if [[ "~{hide_point_mutations}" == "true" ]]; then
+      awk -F "\t" '$11 != "POINT"' ~{samplename}_amrfinder_all.tsv >> temp.tsv
+      mv temp.tsv ~{samplename}_amrfinder_all.tsv
     fi
 
     # Element Type possibilities: AMR, STRESS, and VIRULENCE 

--- a/tasks/gene_typing/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/task_amrfinderplus.wdl
@@ -12,7 +12,7 @@ task amrfinderplus_nuc {
     Float? mincov
     Boolean detailed_drug_class = false
     Int cpu = 4
-    String docker = "staphb/ncbi-amrfinderplus:3.10.36"
+    String docker = "staphb/ncbi-amrfinderplus:3.10.42"
     Boolean hide_point_mutations = false
   }
   command <<<

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -18,7 +18,7 @@
     - wf_theiaprok_illumina_pe_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: e2ef1278531c6e19ae4adcd6bd83ca07
+      md5sum: 4a9639d03cb645e573de2be85be52396
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -30,9 +30,9 @@
     - path: miniwdl_run/call-amrfinderplus_task/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "amrfinderplus", "done"]
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_DB_VERSION
-      md5sum: f2805db31ce8498ca8cb9ba16d12548e
+      md5sum: 6d6543d3aacc310fe866c5e90d1dff77
     - path: miniwdl_run/call-amrfinderplus_task/work/AMRFINDER_VERSION
-      md5sum: 8f87daf07709865a95a12013aa2cbe08
+      md5sum: 6206889552f40d7ea91f1d9ae025f23d
     - path: miniwdl_run/call-amrfinderplus_task/work/AMR_GENES
       md5sum: b6017eebef847ac2471107ca6197b5c5
     - path: miniwdl_run/call-amrfinderplus_task/work/DATE


### PR DESCRIPTION
- This PR adds a Boolean input to the tasks/gene_typing/task_amrfinderplus.wdl task called "hide_point_mutations" which is set to false by default
- When this input attribute is set to true, point mutations will be hidden from the AMRFinderPlus string output columns. The point mutations will still be maintained in the output tsv files

- Tested on 10 samples without point mutations. List of mutations was not altered https://console.cloud.google.com/storage/browser/fc-1162d2b8-109d-42a8-b1b0-c05141aa98ad/submissions/7b3cdf9f-3737-400c-980d-41d34c58c5b4?authuser=michelle.scribner@theiagen.com
- Tested on 25 samples with and without point mutations. Point mutations were removed: https://console.cloud.google.com/storage/browser/fc-1162d2b8-109d-42a8-b1b0-c05141aa98ad/submissions/dd3f7581-ea8e-4c66-a2f1-fd4c0bccbf5d?authuser=michelle.scribner@theiagen.com