### PR TITLE
Fix gambit parsing for next_taxon_rank is None

### DIFF
--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -76,16 +76,16 @@ task gambit {
     # Next taxon
     with open('NEXT_TAXON', 'w') as f:
       if next_taxon is None:
-        f.write(predicted['name'])
+        f.write('NA')
       elif next_taxon['name'] is None:
-        f.write(predicted['name'])
+        f.write('NA')
       else:
         f.write(next_taxon['name'])
     with open('NEXT_TAXON_RANK', 'w') as f:
       if next_taxon is None:
-        f.write(predicted['rank'])
+        f.write('NA')
       elif next_taxon['rank'] is None:
-        f.write(predicted['rank'])
+        f.write('NA')
       else:
         f.write(next_taxon['rank'])
     with open('NEXT_TAXON_THRESHOLD', 'w') as f:

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -90,7 +90,7 @@
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/test_1.clean.fastq.gz
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/test_2.clean.fastq.gz
     - path: miniwdl_run/call-gambit/command
-      md5sum: 8408c43cf723efaf1a7d28332a5a2024
+      md5sum: ff882c65730f22c4d1f8ec80fc52dd5a
     - path: miniwdl_run/call-gambit/inputs.json
       contains: ["assembly", "fasta", "samplename", "test"]
     - path: miniwdl_run/call-gambit/outputs.json


### PR DESCRIPTION
This PR resolves an issue with parsing the gambit output json file in the tasks_gambit.wdl task for the unusual scenario in which both the predicted_taxon_rank and next_taxon_rank are None.

Specifically, if both the  the predicted_taxon_rank and next_taxon_rank variables are None the gambit task fails with the following error, because the task attempts to write None to the NEXT_TAXON_RANK file.
> TypeError: write() argument must be str, not None

To avoid this error when next_taxon_rank is None, we previously included a conditional in line 88 that will write the predicted_taxon_rank rather than the next_taxon_rank to the NEXT_TAXON_RANK file if next_taxon_rank is None. However, if predicted_taxon_rank is also None, the task fails.

I have altered the parsing script to write 'NA' to the NEXT_TAXON_RANK file if the next_taxon_rank variable is None. I also altered the script to write  'NA' to the NEXT_TAXON file if the next_taxon variable is None.