### PR TITLE
update default mlst docker image to staphb/mlst:2.23.0 & fix CI env

### DIFF
--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -64,7 +64,7 @@ jobs:
       # Depends and env info (mostly for debug)
       - name: Install Dependencies
         run: |
-          conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow
+          conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow importlib-metadata<=4.13.0
           uname -a && env
 
       - name: Test ${{ matrix.tag }}

--- a/.github/workflows/pytest-workflows.yml
+++ b/.github/workflows/pytest-workflows.yml
@@ -64,7 +64,7 @@ jobs:
       # Depends and env info (mostly for debug)
       - name: Install Dependencies
         run: |
-          conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow importlib-metadata<=4.13.0
+          conda install -y -c conda-forge -c bioconda cromwell miniwdl=1.5.2 'python>=3.7' pytest pytest-workflow 'importlib-metadata<=4.13.0'
           uname -a && env
 
       - name: Test ${{ matrix.tag }}

--- a/tasks/species_typing/task_ts_mlst.wdl
+++ b/tasks/species_typing/task_ts_mlst.wdl
@@ -7,8 +7,8 @@ task ts_mlst {
   input {
     File assembly
     String samplename
-    String docker = "staphb/mlst:2.22.0"
-    Int? cpu = 4
+    String docker = "staphb/mlst:2.23.0"
+    Int cpu = 4
     # Parameters
     # --nopath          Strip filename paths from FILE column (default OFF)
     # --scheme [X]      Don't autodetect, force this scheme on all inputs (default '')

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -334,7 +334,7 @@
       contains: ["mlst", "depend", "Done"]
     - path: miniwdl_run/call-ts_mlst/stderr.txt.offset
     - path: miniwdl_run/call-ts_mlst/stdout.txt
-      md5sum: 4999136655ea4799df028af149742d87
+      md5sum: 98423ec82f0beb4852c1cbfddda79fff
     - path: miniwdl_run/call-ts_mlst/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "ts_mlst", "done"]
     - path: miniwdl_run/call-ts_mlst/work/PREDICTED_MLST
@@ -342,7 +342,7 @@
     - path: miniwdl_run/call-ts_mlst/work/PUBMLST_SCHEME
       md5sum: e321471812e5c4b54c9c58319aec9f2b
     - path: miniwdl_run/call-ts_mlst/work/VERSION
-      md5sum: 27ff9dc14d779bc4bea1df4d0b1f8f9c
+      md5sum: 04955c2e9f7487411717e7bf9afafb59
     - path: miniwdl_run/call-ts_mlst/work/_miniwdl_inputs/0/test_contigs.fasta
     - path: miniwdl_run/call-ts_mlst/work/test_ts_mlst.tsv
       md5sum: cb4c953253bd9fe6ea9ceda9e57ac172


### PR DESCRIPTION
also removed uneccessary question mark in `cpu` input for `mlst` task

Also had to adjust the CI dependency install because `importlib-metadata` 5.0.0 introduced breaking changes. It now installs `importlib-metadata<=4.13.0` 

Found this in the `log.err` file upon the first CI check: `AttributeError: 'EntryPoints' object has no attribute 'get'`

Tested with a few E. coli/Shigella in Terra here, everything ran as expected: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/22509245-3a52-48b4-9048-9d8ef915777e