### PR TITLE
Update cg_pipeline input to clean reads

### DIFF
--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -96,8 +96,8 @@ workflow theiaprok_illumina_pe {
       }
       call cg_pipeline.cg_pipeline {
         input:
-          read1 = read1_raw,
-          read2 = read2_raw,
+          read1 = read_QC_trim.read1_clean,
+          read2 = read_QC_trim.read2_clean,
           samplename = samplename,
           genome_length = select_first([genome_size, clean_check_reads.est_genome_length])
       }

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -89,7 +89,7 @@ workflow theiaprok_illumina_se {
       }
       call cg_pipeline.cg_pipeline {
         input:
-          read1 = read1_raw,
+          read1 = read_QC_trim.read1_clean,
           samplename = samplename,
           genome_length = select_first([genome_size, clean_check_reads.est_genome_length])
       }


### PR DESCRIPTION
This PR addresses issue #164 

The cg_pipeline task within TheiaProk_Illumina_PE and TheiaProk_Illumina_SE currently calculates the estimated coverage (est_coverage) with the raw reads as input. We propose changing the workflow so that the task takes in the clean reads as input so as not to inflate the coverage estimate.