### PR TITLE
Add option to kSNP3 to create maximum likelihood and neighbor joining trees

### DIFF
--- a/tasks/phylogenetic_inference/task_ksnp3.wdl
+++ b/tasks/phylogenetic_inference/task_ksnp3.wdl
@@ -6,6 +6,7 @@ task ksnp3 {
     Array[String] samplename
     String cluster_name
     Int kmer_size = 19
+    String? ksnp3_args = "" # add -ML to calculate a maximum likelihood tree or -NJ to calculate a neighbor-joining tree
     String docker_image = "quay.io/staphb/ksnp3:3.1"
     Int memory = 8
     Int cpu = 4
@@ -31,15 +32,21 @@ task ksnp3 {
     echo -e "${assembly}\t${samplename}" >> ksnp3_input.tsv
   done
   # run ksnp3 on input assemblies
-  kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core -vcf
+  kSNP3 -in ksnp3_input.tsv -outdir ksnp3 -k ~{kmer_size} -core -vcf ~{ksnp3_args}
   
   # rename ksnp3 outputs with cluster name 
   mv -v ksnp3/core_SNPs_matrix.fasta ksnp3/~{cluster_name}_core_SNPs_matrix.fasta
   mv -v ksnp3/tree.core.tre ksnp3/~{cluster_name}_core.nwk
   mv -v ksnp3/VCF.*.vcf ksnp3/~{cluster_name}_core.vcf
   mv -v ksnp3/SNPs_all_matrix.fasta ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta
-  mv -v ksnp3/tree.parsimony.tre ksnp3/~{cluster_name}_pan_parsiomony.nwk
-  
+  mv -v ksnp3/tree.parsimony.tre ksnp3/~{cluster_name}_pan_parsimony.nwk
+
+  if [ -f ksnp3/tree.ML.tre ]; then  
+    mv -v ksnp3/tree.ML.tre ksnp3/~{cluster_name}_ML.nwk
+  fi 
+  if [ -f ksnp3/tree.NJ.tre ]; then  
+    mv -v ksnp3/tree.NJ.tre ksnp3/~{cluster_name}_NJ.nwk
+  fi 
 
   >>>
   output {
@@ -47,7 +54,10 @@ task ksnp3 {
     File ksnp3_core_tree = "ksnp3/${cluster_name}_core.nwk"
     File ksnp3_core_vcf = "ksnp3/${cluster_name}_core.vcf"
     File ksnp3_pan_matrix = "ksnp3/~{cluster_name}_pan_SNPs_matrix.fasta"
-    File ksnp3_pan_parsimony_tree = "ksnp3/~{cluster_name}_pan_parsiomony.nwk"
+    File ksnp3_pan_parsimony_tree = "ksnp3/~{cluster_name}_pan_parsimony.nwk"
+    File? ksnp3_ml_tree = "ksnp3/~{cluster_name}_ML.nwk"
+    File? ksnp3_nj_tree = "ksnp3/~{cluster_name}_NJ.nwk"
+    File number_snps = "ksnp3/COUNT_SNPs"
     Array[File] ksnp_outs = glob("ksnp3/*")
     String ksnp3_docker_image = docker_image
   }

--- a/workflows/wf_ksnp3.wdl
+++ b/workflows/wf_ksnp3.wdl
@@ -40,6 +40,8 @@ workflow ksnp3_workflow {
     File ksnp3_core_vcf = ksnp3_task.ksnp3_core_vcf
     File ksnp3_pan_snp_matrix = pan_snp_dists.snp_matrix
     File ksnp3_pan_parsimony_tree = ksnp3_task.ksnp3_pan_parsimony_tree
+    File? ksnp3_ml_tree = ksnp3_task.ksnp3_ml_tree
+    File? ksnp3_nj_tree = ksnp3_task.ksnp3_nj_tree
     String ksnp3_docker = ksnp3_task.ksnp3_docker_image
   }
 }


### PR DESCRIPTION
This PR adds an optional input to the ksnp3 task (tasks/phylogenetic_inference/task_ksnp3.wdl) that allows the user to add additional arguments to kSNP3. Two arguments that may be helpful to add are "-ML" or "-NJ", which will cause the workflow to output maximum likelihood or neighbor joining trees, respectively, in addition to the default parsimony tree.

This PR also adds the maximum likelihood and neighbor joining trees as optional outputs.

The branch has been tested using no additional flags, the "-ML" flag, and the "-NJ" flag on a small set of samples.