### PR TITLE
add optional input to merlin_magic wf for skipping serotypefinder and specify docker image

### DIFF
--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -36,6 +36,7 @@ workflow merlin_magic {
     Boolean call_poppunk = true
     Boolean read1_is_ont = false
     Boolean skip_serotypefinder = false
+    String? serotypefinder_docker_image
   }
     if (merlin_tag == "Acinetobacter baumannii") {
     call kaptive.kaptive {
@@ -57,7 +58,8 @@ workflow merlin_magic {
     call serotypefinder.serotypefinder {
       input:
         assembly = assembly,
-        samplename = samplename
+        samplename = samplename,
+        docker = serotypefinder_docker_image
     }
     }
     call ectyper.ectyper {

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -35,6 +35,7 @@ workflow merlin_magic {
     Boolean paired_end = true
     Boolean call_poppunk = true
     Boolean read1_is_ont = false
+    Boolean skip_serotypefinder = false
   }
     if (merlin_tag == "Acinetobacter baumannii") {
     call kaptive.kaptive {
@@ -52,10 +53,12 @@ workflow merlin_magic {
   }
   if (merlin_tag == "Escherichia" || merlin_tag == "Shigella_sonnei" ) {
     # tools specific to all Escherichia and Shigella species
+    if (! skip_serotypefinder) {
     call serotypefinder.serotypefinder {
       input:
         assembly = assembly,
         samplename = samplename
+    }
     }
     call ectyper.ectyper {
       input:


### PR DESCRIPTION
This PR adds an optional boolean input `skip_serotypefinder` to the merlin magic workflow to allow the user to skip the usage of serotypefinder via the Esherichia sub-workflow. It is by default set to `false` but the user can set it to `true` 

This PR also adds an optional input `String? serotypefinder_docker_image` to allow the user to specify the docker image used (in case there are new versions & docker images in the future)

The original rationale for adding this is to avoid cryptic & hard-to-troubleshoot bugs with serotypefinder. I've very rarely encountered errors with SerotypeFinder and want TheiaProk workflow to run successfully despite the rare serotypefinder error.

More details on the SerotypeFinder bug here, its related to blastn output and XML parsing: https://bitbucket.org/genomicepidemiology/serotypefinder/issues/3/xmlparsersexpatexpaterror-mismatched-tag

This error has since been resolved ^ and the docker image `staphb/serotypefinder:2.0.1` ~~will soon be updated to prevent the error~~ docker image has been fixed, but still would be good to have the functionality in the workflow

Tested sucessfully w/ miniwdl and in Terra.

Successful Terra test (n=1): https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/b5542011-622e-4c1b-a255-cdc016bf581f