### PR TITLE
Revert default read trimming parameters to v1.0

### DIFF
--- a/tasks/quality_control/task_fastp.wdl
+++ b/tasks/quality_control/task_fastp.wdl
@@ -6,9 +6,9 @@ task fastp {
     File read2
     String samplename
     String docker = "quay.io/staphb/fastp:0.23.2"
-    Int fastp_minlen = 50
     Int fastp_window_size = 20
     Int fastp_quality_trim_score = 30
+    Int fastp_minlen = 50
     # -g enables polyg trimming with default value of 10
     String fastp_args = "--detect_adapter_for_pe -g -5 20 -3 20"
     Int threads = 4
@@ -51,9 +51,9 @@ task fastp_se {
     File read1
     String samplename
     String docker = "quay.io/staphb/fastp:0.23.2"
-    Int fastp_minlen = 50
     Int fastp_window_size = 20
     Int fastp_quality_trim_score = 30
+    Int fastp_minlen = 50
     # -g enables polyg trimming with default value of 10
     # --detect_adapter_for_pe argument was removed 
     String fastp_args = "-g -5 20 -3 20"

--- a/tasks/quality_control/task_trimmomatic.wdl
+++ b/tasks/quality_control/task_trimmomatic.wdl
@@ -6,9 +6,9 @@ task trimmomatic_pe {
     File read2
     String samplename
     String docker = "quay.io/staphb/trimmomatic:0.39"
-    Int? trimmomatic_minlen = 75
     Int? trimmomatic_window_size = 10
     Int? trimmomatic_quality_trim_score = 20
+    Int? trimmomatic_minlen = 75
     Int? threads = 4
   }
   command <<<
@@ -44,9 +44,9 @@ task trimmomatic_se {
     File read1
     String samplename
     String docker="quay.io/staphb/trimmomatic:0.39"
+    Int? trimmomatic_window_size = 4
+    Int? trimmomatic_quality_trim_score = 30
     Int? trimmomatic_minlen = 25
-    Int? trimmomatic_window_size=4
-    Int? trimmomatic_quality_trim_score=30
     Int? threads = 4
   }
   command <<<

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -226,13 +226,13 @@
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/_miniwdl_inputs/0/test_1P.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/_miniwdl_inputs/0/test_2P.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.adapters.stats.txt
-      md5sum: 622b48dd90ee5cde7a9057876927f317
+      md5sum: 6328466d2d542ef57fb6843d5aa89611
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.matched_phix.fq
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.paired_1.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.paired_2.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.phix.stats.txt
-      md5sum: 8caec2d678db939a50693308e8c1d7be
+      md5sum: e7c6494642c2131ed1751848c95407f0
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.rmadpt_1.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test.rmadpt_2.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_pe/work/test_1.clean.fastq.gz
@@ -251,19 +251,19 @@
       contains: ["wdl", "theiaprok_illumina_pe", "fastq_scan_clean", "done"]
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/DATE
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/READ1_SEQS
-      md5sum: 01e06bab34671472efee3baaa517595f
+      md5sum: 5fcafec683df465a99878ceaffe8a294
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/READ2_SEQS
-      md5sum: 01e06bab34671472efee3baaa517595f
+      md5sum: 5fcafec683df465a99878ceaffe8a294
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/READ_PAIRS
-      md5sum: 01e06bab34671472efee3baaa517595f
+      md5sum: 5fcafec683df465a99878ceaffe8a294
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/VERSION
       md5sum: 8e4e9cdfbacc9021a3175ccbbbde002b
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/_miniwdl_inputs/0/test_1.clean.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/_miniwdl_inputs/0/test_2.clean.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/test_1.clean_fastq-scan.json
-      md5sum: c6bf0845cae91f6e5489d6566b66e926
+      md5sum: 85d8de64c394c59362419e66badcc594
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_clean/work/test_2.clean_fastq-scan.json
-      md5sum: 581456bf42a239ad84517a3c8997b82b
+      md5sum: 209e27240fc9e3de7b8432da60a2e274
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/command
       md5sum: dd41c4de4594f801e90d70ccb6553c3c
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/inputs.json
@@ -292,7 +292,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/work/_miniwdl_inputs/0/SRR2838702_R1.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-fastq_scan_raw/work/_miniwdl_inputs/0/SRR2838702_R2.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/command
-      md5sum: 49e8433ef6886cecf20a38348511eff8
+      md5sum: 3f966c008f430725abd007b202e726bd
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/inputs.json
       contains: ["read", "fastq", "test", "trimmomatic_minlen"]
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/outputs.json
@@ -308,7 +308,7 @@
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/_miniwdl_inputs/0/SRR2838702_R1.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/_miniwdl_inputs/0/SRR2838702_R2.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/test.trim.stats.txt
-      md5sum: 406ddd86f9f4d88ee0af5960a64bff42
+      md5sum: 509449f69e9593adff0d77cfaece7e91
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/test_1P.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/test_1U.fastq.gz
     - path: miniwdl_run/call-read_QC_trim/call-trimmomatic_pe/work/test_2P.fastq.gz

--- a/workflows/wf_read_QC_trim.wdl
+++ b/workflows/wf_read_QC_trim.wdl
@@ -15,9 +15,9 @@ workflow read_QC_trim {
     String  samplename
     File    read1_raw
     File    read2_raw
-    Int     trim_minlen = 50
-    Int     trim_quality_trim_score = 30
-    Int     trim_window_size = 20
+    Int     trim_window_size = 10
+    Int     trim_quality_trim_score = 20
+    Int     trim_minlen = 75
     Int     bbduk_mem = 8
     Boolean call_midas = false
     File?   midas_db
@@ -30,9 +30,9 @@ workflow read_QC_trim {
         samplename = samplename,
         read1 = read1_raw,
         read2 = read2_raw,
-        trimmomatic_minlen = trim_minlen,
+        trimmomatic_window_size = trim_window_size,
         trimmomatic_quality_trim_score = trim_quality_trim_score,
-        trimmomatic_window_size = trim_window_size
+        trimmomatic_minlen = trim_minlen
     }
   }
   if (read_processing == "fastp"){
@@ -41,9 +41,9 @@ workflow read_QC_trim {
         samplename = samplename,
         read1 = read1_raw,
         read2 = read2_raw,
-        fastp_minlen = trim_minlen,
-        fastp_quality_trim_score = trim_quality_trim_score,
         fastp_window_size = trim_window_size,
+        fastp_quality_trim_score = trim_quality_trim_score,
+        fastp_minlen = trim_minlen,
         fastp_args = fastp_args
     }
   }

--- a/workflows/wf_read_QC_trim_se.wdl
+++ b/workflows/wf_read_QC_trim_se.wdl
@@ -14,9 +14,9 @@ workflow read_QC_trim {
   input {
     String  samplename
     File    read1_raw
-    Int     trim_minlen = 50
+    Int     trim_window_size = 4
     Int     trim_quality_trim_score = 30
-    Int     trim_window_size = 20
+    Int     trim_minlen = 25
     Int     bbduk_mem = 8
     Boolean call_midas = false
     File?   midas_db
@@ -33,9 +33,9 @@ workflow read_QC_trim {
       input:
         samplename = samplename,
         read1 = read1_raw,
-        trimmomatic_minlen = trim_minlen,
+        trimmomatic_window_size = trim_window_size,
         trimmomatic_quality_trim_score = trim_quality_trim_score,
-        trimmomatic_window_size = trim_window_size
+        trimmomatic_minlen = trim_minlen
     }
   }
   if (read_processing == "fastp"){
@@ -43,9 +43,9 @@ workflow read_QC_trim {
       input:
         samplename = samplename,
         read1 = read1_raw,
-        fastp_minlen = trim_minlen,
-        fastp_quality_trim_score = trim_quality_trim_score,
         fastp_window_size = trim_window_size,
+        fastp_quality_trim_score = trim_quality_trim_score,
+        fastp_minlen = trim_minlen,
         fastp_args = fastp_args
     }
   }


### PR DESCRIPTION
### This PR:

- Reverts the trimmomatic default read trimming and filtering parameters back to the values used in the 1.0 release of PHBG in the trimmomatic task and the read_QC_trim workflow. These values were changed in https://github.com/theiagen/public_health_bacterial_genomics/pull/169
- Also reverts back to the values used in the 1.0 release of PHBG in the read_QC_trim_se workflow

- This PR also reorders the inputs in the read_QC_trim wf, read_QC_trim_se wf, trimmomatic task, and fastp task for consistency and to reflect the order of operations used by trimmomatic and fastp

### Testing
This branch has been tested: https://console.cloud.google.com/storage/browser/fc-1162d2b8-109d-42a8-b1b0-c05141aa98ad/submissions/cd7fab66-3f17-4795-b492-647afd3e2c3d?authuser=michelle.scribner@theiagen.com

The number of reads passing filtering were confirmed to match those from v1.0 of TheiaProk

</head>

<body link="#0563C1" vlink="#954F72">


theiaprok v1.0 | num_reads_clean_pairs | num_reads_raw_pairs
-- | -- | --
sample_01 | 1409757 | 1488671
sample_02 | 1255890 | 1308480
sample_03 | 601271 | 776657
sample_04 | 1780521 | 1884728
sample_05 | 542521 | 559802
  |   |  
entity:revert_trim_v1_1_id | num_reads_clean_pairs | num_reads_raw_pairs
sample_01 | 1409757 | 1488671
sample_02 | 1255890 | 1308480
sample_03 | 601271 | 776657
sample_04 | 1780521 | 1884728
sample_05 | 542521 | 559802



</body>

</html>

