### PR TITLE
Generate gene_presence_absence.csv with pirate task

### DIFF
--- a/tasks/phylogenetic_inference/task_pirate.wdl
+++ b/tasks/phylogenetic_inference/task_pirate.wdl
@@ -65,7 +65,7 @@ task pirate {
     File? pirate_pangenome_alignment_gff = "PIRATE/~{cluster_name}_pangenome_alignment.gff"
     File? pirate_core_alignment_fasta = "PIRATE/~{cluster_name}_core_alignment.fasta"
     File? pirate_core_alignment_gff = "PIRATE/~{cluster_name}_core_alignment.gff"
-    File pirate_presence_absence_csv = "~{cluster_name}_gene_presence_absence.csv"
+    File? pirate_presence_absence_csv = "~{cluster_name}_gene_presence_absence.csv"
     String pirate_docker_image = docker_image
   } 
   runtime {

--- a/tasks/phylogenetic_inference/task_pirate.wdl
+++ b/tasks/phylogenetic_inference/task_pirate.wdl
@@ -32,7 +32,10 @@ task pirate {
   ~{true="--nucl" false="" nucl} \
   ~{true="--align" false="" align} \
   ~{'--pan-opt ' + panopt} \
-  ~{'--threads ' + cpu} 
+  ~{'--threads ' + cpu}
+  
+  # generate gene_presence_absence.csv
+  PIRATE_to_roary.pl -i PIRATE/PIRATE.*.tsv -o ~{cluster_name}_gene_presence_absence.csv
   
   # rename outputs with cluster name 
   mv PIRATE/PIRATE.pangenome_summary.txt PIRATE/~{cluster_name}_pangenome_summary.txt
@@ -62,6 +65,7 @@ task pirate {
     File? pirate_pangenome_alignment_gff = "PIRATE/~{cluster_name}_pangenome_alignment.gff"
     File? pirate_core_alignment_fasta = "PIRATE/~{cluster_name}_core_alignment.fasta"
     File? pirate_core_alignment_gff = "PIRATE/~{cluster_name}_core_alignment.gff"
+    File pirate_presence_absence_csv = "~{cluster_name}_gene_presence_absence.csv"
     String pirate_docker_image = docker_image
   } 
   runtime {

--- a/workflows/wf_core_gene_snp.wdl
+++ b/workflows/wf_core_gene_snp.wdl
@@ -63,6 +63,7 @@ workflow core_gene_snp_workflow {
     File? pirate_core_alignment_gff = pirate.pirate_core_alignment_gff
     File? pirate_pan_alignment_fasta = pirate.pirate_pangenome_alignment_fasta
     File? pirate_pan_alignment_gff = pirate.pirate_pangenome_alignment_gff
+    File? pirate_presence_absence_csv = pirate.pirate_presence_absence_csv
     String pirate_docker_image = pirate.pirate_docker_image
     # snp_dists outputs
     String? pirate_snps_dists_version = select_first([core_snp_dists.version,pan_snp_dists.version])


### PR DESCRIPTION
I added in one line of code (and a few lines to save the related output file) to the pirate task to generate a gene_presence_absence.csv file that is comparable to the gene_presence_absence.csv file generated when running Roary. This allows you to use many of the post-alignment tools created for Roary on the output from Pirate (such as SCOARY, roary_plot.py, etc)