### PR TITLE
Update task_amrfinderplus.wdl

### DIFF
--- a/tasks/gene_typing/task_amrfinderplus.wdl
+++ b/tasks/gene_typing/task_amrfinderplus.wdl
@@ -41,7 +41,7 @@ task amrfinderplus_nuc {
     elif [[ "~{organism}" == *"Escherichia"* ]] || [[ "~{organism}" == *"Shigella"* ]]; then 
       amrfinder_organism="Escherichia"
     # add other Klebsiella species later? Cannot use K. oxytoca as per amrfinderplus wiki
-    elif [[ "~{organism}" == *"Klebsiella"*"aerogenes"* ]] || [[ "~{organism}" == *"Klebsiella"*"pnemoniae"* ]]; then 
+    elif [[ "~{organism}" == *"Klebsiella"*"aerogenes"* ]] || [[ "~{organism}" == *"Klebsiella"*"pneumoniae"* ]]; then 
       amrfinder_organism="Klebsiella"
     # because some people spell the species 'gonorrhea' differently
     elif [[ "~{organism}" == *"Neisseria"*"gonorrhea"* ]] || [[ "~{organism}" == *"Neisseria"*"gonorrhoeae"* ]] || [[ "~{organism}" == *"Neisseria"*"meningitidis"* ]]; then 

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -18,7 +18,7 @@
     - wf_theiaprok_illumina_pe_miniwdl
   files:
     - path: miniwdl_run/call-amrfinderplus_task/command
-      md5sum: 4a9639d03cb645e573de2be85be52396
+      md5sum: 01d18414847e11311bac87778d1376f6
     - path: miniwdl_run/call-amrfinderplus_task/inputs.json
       contains: ["assembly", "fasta", "organism", "test"]
     - path: miniwdl_run/call-amrfinderplus_task/outputs.json


### PR DESCRIPTION
This PR fixes a typo made RE `pnemoniae` v. `pneumoniae`