### PR TITLE
mlst: new String output "ts_mlst_allelic_profile"

### DIFF
--- a/tasks/species_typing/task_ts_mlst.wdl
+++ b/tasks/species_typing/task_ts_mlst.wdl
@@ -40,12 +40,16 @@ task ts_mlst {
       >> ~{samplename}_ts_mlst.tsv
       
     # parse ts mlst tsv for relevant outputs
+    # if output TSV only contains one line (header line); no ST predicted
     if [ $(wc -l ~{samplename}_ts_mlst.tsv | awk '{ print $1 }') -eq 1 ]; then
       predicted_mlst="No ST predicted"
       pubmlst_scheme="NA"
+    # else, TSV has more than one line, so parse outputs
     else
       pubmlst_scheme="$(cut -f2 ~{samplename}_ts_mlst.tsv | tail -n 1)"
       predicted_mlst="ST$(cut -f3 ~{samplename}_ts_mlst.tsv | tail -n 1)"
+      # allelic_profile: take second line of output TSV; cut to take 4th column and beyond; replace tabs with commas
+      allelic_profile="$(cut -f 4- ~{samplename}_ts_mlst.tsv | tail -n 1 | sed -e 's|\t|,|g')"
         if [ "$pubmlst_scheme" == "-" ]; then
           predicted_mlst="No ST predicted"
           pubmlst_scheme="NA"
@@ -56,13 +60,15 @@ task ts_mlst {
         fi  
     fi
     
-    echo $predicted_mlst | tee PREDICTED_MLST
-    echo $pubmlst_scheme | tee PUBMLST_SCHEME
+    echo "$predicted_mlst" | tee PREDICTED_MLST
+    echo "$pubmlst_scheme" | tee PUBMLST_SCHEME
+    echo "$allelic_profile" | tee ALLELIC_PROFILE.txt
   >>>
   output {
     File ts_mlst_results = "~{samplename}_ts_mlst.tsv"
     String ts_mlst_predicted_st = read_string("PREDICTED_MLST")
     String ts_mlst_pubmlst_scheme = read_string("PUBMLST_SCHEME")
+    String ts_mlst_allelic_profile = read_string("ALLELIC_PROFILE.txt")
     File? ts_mlst_novel_alleles = "~{samplename}_novel_mlst_alleles.fasta"
     String ts_mlst_version = read_string("VERSION")
   }

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -98,6 +98,7 @@ task export_taxon_tables {
     String ts_mlst_results
     String ts_mlst_predicted_st
     String ts_mlst_pubmlst_scheme
+    String ts_mlst_allelic_profile
     String? ts_mlst_novel_alleles
     String ts_mlst_version
     File? serotypefinder_report
@@ -343,6 +344,7 @@ task export_taxon_tables {
       "ts_mlst_results": "~{ts_mlst_results}",
       "ts_mlst_predicted_st": "~{ts_mlst_predicted_st}",
       "ts_mlst_pubmlst_scheme": "~{ts_mlst_pubmlst_scheme}",
+      "ts_mlst_allelic_profile": "~{ts_mlst_allelic_profile}",
       "ts_mlst_novel_alleles": "~{ts_mlst_novel_alleles}",
       "ts_mlst_version": "~{ts_mlst_version}",
       "serotypefinder_report": "~{serotypefinder_report}",

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -358,6 +358,8 @@
       md5sum: c55d857f0c5bda37f86000ed996f2c0c
     - path: miniwdl_run/call-ts_mlst/work/PUBMLST_SCHEME
       md5sum: e321471812e5c4b54c9c58319aec9f2b
+    - path: miniwdl_run/call-ts_mlst/work/ALLELIC_PROFILE.txt
+      md5sum: 04955c2e9f7487411717e7bf9afafb59
     - path: miniwdl_run/call-ts_mlst/work/VERSION
       md5sum: 04955c2e9f7487411717e7bf9afafb59
     - path: miniwdl_run/call-ts_mlst/work/_miniwdl_inputs/0/test_contigs.fasta

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -359,7 +359,7 @@
     - path: miniwdl_run/call-ts_mlst/work/PUBMLST_SCHEME
       md5sum: e321471812e5c4b54c9c58319aec9f2b
     - path: miniwdl_run/call-ts_mlst/work/ALLELIC_PROFILE.txt
-      md5sum: 04955c2e9f7487411717e7bf9afafb59
+      md5sum: 68b329da9893e34099c7d8ad5cb9c940
     - path: miniwdl_run/call-ts_mlst/work/VERSION
       md5sum: 04955c2e9f7487411717e7bf9afafb59
     - path: miniwdl_run/call-ts_mlst/work/_miniwdl_inputs/0/test_contigs.fasta

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -342,7 +342,7 @@
     - path: miniwdl_run/call-shovill_pe/work/out/skesa.fasta
     - path: miniwdl_run/call-shovill_pe/work/out/test_contigs.fasta
     - path: miniwdl_run/call-ts_mlst/command
-      md5sum: 004ab8636cedb1b8c67c7c786f374fe1
+      md5sum: 75b5dd0a081f674fb7988b0c9c50ef91
     - path: miniwdl_run/call-ts_mlst/inputs.json
       contains: ["assembly", "fasta", "sample", "test"]
     - path: miniwdl_run/call-ts_mlst/outputs.json
@@ -351,7 +351,7 @@
       contains: ["mlst", "depend", "Done"]
     - path: miniwdl_run/call-ts_mlst/stderr.txt.offset
     - path: miniwdl_run/call-ts_mlst/stdout.txt
-      md5sum: 98423ec82f0beb4852c1cbfddda79fff
+      md5sum: 7fcd2d255db3890f69dbbb968812a6cb
     - path: miniwdl_run/call-ts_mlst/task.log
       contains: ["wdl", "theiaprok_illumina_pe", "ts_mlst", "done"]
     - path: miniwdl_run/call-ts_mlst/work/PREDICTED_MLST

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -297,6 +297,7 @@ workflow theiaprok_illumina_pe {
             ts_mlst_results = ts_mlst.ts_mlst_results,
             ts_mlst_predicted_st = ts_mlst.ts_mlst_predicted_st,
             ts_mlst_pubmlst_scheme = ts_mlst.ts_mlst_pubmlst_scheme,
+            ts_mlst_allelic_profile = ts_mlst.ts_mlst_allelic_profile,
             ts_mlst_version = ts_mlst.ts_mlst_version,
             ts_mlst_novel_alleles = ts_mlst.ts_mlst_novel_alleles,
             serotypefinder_report = merlin_magic.serotypefinder_report,
@@ -541,6 +542,7 @@ workflow theiaprok_illumina_pe {
     File? ts_mlst_results = ts_mlst.ts_mlst_results
     String? ts_mlst_predicted_st = ts_mlst.ts_mlst_predicted_st
     String? ts_mlst_pubmlst_scheme = ts_mlst.ts_mlst_pubmlst_scheme
+    String? ts_mlst_allelic_profile = ts_mlst.ts_mlst_allelic_profile
     String? ts_mlst_version = ts_mlst.ts_mlst_version
     File? ts_mlst_novel_alleles = ts_mlst.ts_mlst_novel_alleles
     # Prokka Results

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -245,6 +245,7 @@ workflow theiaprok_illumina_se {
             ts_mlst_results = ts_mlst.ts_mlst_results,
             ts_mlst_predicted_st = ts_mlst.ts_mlst_predicted_st,
             ts_mlst_pubmlst_scheme = ts_mlst.ts_mlst_pubmlst_scheme,
+            ts_mlst_allelic_profile = ts_mlst.ts_mlst_allelic_profile,
             ts_mlst_version = ts_mlst.ts_mlst_version,
             ts_mlst_novel_alleles = ts_mlst.ts_mlst_novel_alleles,
             serotypefinder_report = merlin_magic.serotypefinder_report,
@@ -471,6 +472,7 @@ workflow theiaprok_illumina_se {
     String? ts_mlst_predicted_st = ts_mlst.ts_mlst_predicted_st
     String? ts_mlst_version = ts_mlst.ts_mlst_version
     String? ts_mlst_pubmlst_scheme = ts_mlst.ts_mlst_pubmlst_scheme
+    String? ts_mlst_allelic_profile = ts_mlst.ts_mlst_allelic_profile
     File? ts_mlst_novel_alleles = ts_mlst.ts_mlst_novel_alleles
     # Prokka Results
     File? prokka_gff = prokka.prokka_gff


### PR DESCRIPTION
~~Setting as a draft until testing in Terra is complete~~

**Ready for review**

This PR:

- adds a new String output to the `ts_mlst` task called `ts_mlst_allelic_profile` which is a comma-separated list of genes
  - E. coli ST11 example: `adk(12),fumC(12),gyrB(8),icd(12),mdh(15),purA(2),recA(2)`
- adds this new output to both TheiaProk_Illumina_PE and TheiaProk_Illumina_SE workflows
- adds this new output to the export_taxon_tables task

Testing on Terra:
- [x] ILMN PE
- [x] ILMN SE