### PR TITLE
Add neisseria subwf: ngmaster and meningotype

### DIFF
--- a/tasks/species_typing/task_meningotype.wdl
+++ b/tasks/species_typing/task_meningotype.wdl
@@ -10,37 +10,46 @@ task meningotype {
     String docker = "quay.io/biocontainers/meningotype:0.8.5--pyhdfd78af_0"
     Int disk_size = 100
     Int cpu = 2
-
+  }
+  command <<<
+    
     # Parameters
     # --finetype      perform porA and fetA fine typing (default=off)
     # --porB          perform porB sequence typing (NEIS2020) (default=off)
     # --bast          perform Bexsero antigen sequence typing (BAST) (default=off)
     # --mlst          perform MLST (default=off)
     # --all           perform MLST, porA, fetA, porB, BAST typing (default=off)
-    Boolean finetype = false
-    Boolean porB = false
-    Boolean bast = false
-    Boolean mlst = false
-    Boolean all = false
-  }
-  command <<<
+
     echo $(meningotype --version 2>&1) | sed 's/^.*meningotype v//' | tee VERSION
     meningotype \
-      ~{true="--finetype" false="" finetype} \
-      ~{true="--porB" false="" porB} \
-      ~{true="--bast" false="" bast} \
-      ~{true="--mlst" false="" mlst} \
-      ~{true="--all" false="" all} \
+      --finetype \
+      --porB \
+      --bast \
       --cpus ~{cpu} \
       ~{assembly} \
       > ~{samplename}.tsv
     
     tail -1 ~{samplename}.tsv | awk '{print $2}' | tee MENINGOTYPE_SEROTYPE
+    tail -1 ~{samplename}.tsv | awk '{print $5}' | tee MENINGOTYPE_PORA
+    tail -1 ~{samplename}.tsv | awk '{print $6}' | tee MENINGOTYPE_FETA
+    tail -1 ~{samplename}.tsv | awk '{print $7}' | tee MENINGOTYPE_PORB
+    tail -1 ~{samplename}.tsv | awk '{print $8}' | tee MENINGOTYPE_FHBP
+    tail -1 ~{samplename}.tsv | awk '{print $9}' | tee MENINGOTYPE_NHBA
+    tail -1 ~{samplename}.tsv | awk '{print $10}' | tee MENINGOTYPE_NADA
+    tail -1 ~{samplename}.tsv | awk '{print $11}' | tee MENINGOTYPE_BAST
+
   >>>
   output {
     File meningotype_tsv = "~{samplename}.tsv"
     String meningotype_version = read_string("VERSION")
     String meningotype_serogroup = read_string("MENINGOTYPE_SEROTYPE")
+    String meningotype_PorA = read_string("MENINGOTYPE_PORA")
+    String meningotype_FetA = read_string("MENINGOTYPE_FETA")
+    String meningotype_PorB = read_string("MENINGOTYPE_PORB")
+    String meningotype_fHbp = read_string("MENINGOTYPE_FHBP")
+    String meningotype_NHBA = read_string("MENINGOTYPE_NHBA")
+    String meningotype_NadA = read_string("MENINGOTYPE_NADA")
+    String meningotype_BAST = read_string("MENINGOTYPE_BAST")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/species_typing/task_meningotype.wdl
+++ b/tasks/species_typing/task_meningotype.wdl
@@ -34,10 +34,13 @@ task meningotype {
       --cpus ~{cpu} \
       ~{assembly} \
       > ~{samplename}.tsv
+    
+    tail -1 ~{samplename}.tsv | awk '{print $2}' | tee MENINGOTYPE_SEROTYPE
   >>>
   output {
     File meningotype_tsv = "~{samplename}.tsv"
     String meningotype_version = read_string("VERSION")
+    String meningotype_serogroup = read_string("MENINGOTYPE_SEROTYPE")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/species_typing/task_meningotype.wdl
+++ b/tasks/species_typing/task_meningotype.wdl
@@ -9,7 +9,7 @@ task meningotype {
     String samplename
     String docker = "quay.io/biocontainers/meningotype:0.8.5--pyhdfd78af_0"
     Int disk_size = 100
-    Int? cpu = 2
+    Int cpu = 2
 
     # Parameters
     # --finetype      perform porA and fetA fine typing (default=off)
@@ -36,13 +36,13 @@ task meningotype {
       > ~{samplename}.tsv
   >>>
   output {
-    File meningotype_results = "~{samplename}.tsv"
+    File meningotype_tsv = "~{samplename}.tsv"
     String meningotype_version = read_string("VERSION")
   }
   runtime {
     docker: "~{docker}"
     memory: "8 GB"
-    cpu: 2
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/species_typing/task_ngmaster.wdl
+++ b/tasks/species_typing/task_ngmaster.wdl
@@ -7,7 +7,7 @@ task ngmaster {
   input {
     File assembly
     String samplename
-    String docker = "kapsakcj/ngmaster:1.0.0" # will change to staphb/ngmaster:1.0.0 once it is available
+    String docker = "staphb/ngmaster:1.0.0" 
     Int disk_size = 100
     Int cpu = 2
   }

--- a/tasks/species_typing/task_ngmaster.wdl
+++ b/tasks/species_typing/task_ngmaster.wdl
@@ -9,7 +9,7 @@ task ngmaster {
     String samplename
     String docker = "quay.io/biocontainers/ngmaster:0.5.8--pyhdfd78af_1"
     Int disk_size = 100
-    Int? cpu = 2
+    Int cpu = 2
   }
   command <<<
     echo $(ngmaster --version 2>&1) | sed 's/^.*ngmaster //' | tee VERSION
@@ -18,13 +18,13 @@ task ngmaster {
       > ~{samplename}.tsv
   >>>
   output {
-    File ngmaster_results = "~{samplename}.tsv"
+    File ngmaster_tsv = "~{samplename}.tsv"
     String ngmaster_version = read_string("VERSION")
   }
   runtime {
     docker: "~{docker}"
     memory: "8 GB"
-    cpu: 2
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/species_typing/task_ngmaster.wdl
+++ b/tasks/species_typing/task_ngmaster.wdl
@@ -7,19 +7,52 @@ task ngmaster {
   input {
     File assembly
     String samplename
-    String docker = "quay.io/biocontainers/ngmaster:0.5.8--pyhdfd78af_1"
+    String docker = "kapsakcj/ngmaster:1.0.0" # will change to staphb/ngmaster:1.0.0 once it is available
     Int disk_size = 100
     Int cpu = 2
   }
   command <<<
-    echo $(ngmaster --version 2>&1) | sed 's/^.*ngmaster //' | tee VERSION
+    ngmaster --version 2>&1 | sed 's/^.*ngmaster //' | tee VERSION
+
+    # run ngmaster on input assembly
+    # unfortunately ngmaster 1.0.0 fails when either mincov or minid flags are supplied (this is with different install strategies too - bioconda & manually)
+    # so we're forced to stick with default minid of 90 and mincov of 10. https://github.com/MDU-PHL/ngmaster/issues/39
+    # ngmaster --comments also does not work
     ngmaster \
       ~{assembly} \
-      > ~{samplename}.tsv
+      > ~{samplename}.ngmaster.tsv
+
+    # parse output TSV
+    # first one is tricky since MLSTs are in the 3rd column, separated by a /
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $3}' | cut -d '/' -f 1 | tee NGMAST_SEQUENCE_TYPE
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $3}' | cut -d '/' -f 2 | tee NGSTAR_SEQUENCE_TYPE
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $4}' | tee NGMAST_PORB
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $5}' | tee NGMAST_TBPB
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $6}' | tee NGSTAR_PENA
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $7}' | tee NGSTAR_MTRR
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $8}' | tee NGSTAR_PORB
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $9}' | tee NGSTAR_PONA
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $10}' | tee NGSTAR_GYRA
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $11}' | tee NGSTAR_PARC
+    tail -n 1 ~{samplename}.ngmaster.tsv | awk '{print $12}' | tee NGSTAR_23S
+
   >>>
   output {
-    File ngmaster_tsv = "~{samplename}.tsv"
+    File ngmaster_tsv = "~{samplename}.ngmaster.tsv"
     String ngmaster_version = read_string("VERSION")
+    # NG-MAST scheme's MLST and alleles (only 2 loci)
+    String ngmaster_ngmast_sequence_type = read_string("NGMAST_SEQUENCE_TYPE")
+    String ngmaster_ngmast_porB_allele = read_string("NGMAST_PORB")
+    String ngmaster_ngmast_tbpB_allele = read_string("NGMAST_TBPB")
+    # NG-STAR scheme's MLST and alleles (7 loci)
+    String ngmaster_ngstar_sequence_type = read_string("NGSTAR_SEQUENCE_TYPE")
+    String ngmaster_ngstar_penA_allele = read_string("NGSTAR_PENA")
+    String ngmaster_ngstar_mtrR_allele = read_string("NGSTAR_MTRR")
+    String ngmaster_ngstar_porB_allele = read_string("NGSTAR_PORB")
+    String ngmaster_ngstar_ponA_allele = read_string("NGSTAR_PONA")
+    String ngmaster_ngstar_gyrA_allele = read_string("NGSTAR_GYRA")
+    String ngmaster_ngstar_parC_allele = read_string("NGSTAR_PARC")
+    String ngmaster_ngstar_23S_allele = read_string("NGSTAR_23S")
   }
   runtime {
     docker: "~{docker}"

--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -154,6 +154,10 @@ task gambit {
       merlin_tag="Mycobacterium tuberculosis"
     elif [[ ${predicted_taxon} == *"Neisseria"* ]]; then 
       merlin_tag="Neisseria"
+      # if predicted taxon is Neisseria gonorrhoeae, reset merlin_tag to Neisseria gonorrhoeae
+      if [[ ${predicted_taxon} == *"Neisseria gonorrhoeae"* ]]; then 
+        merlin_tag="Neisseria gonorrhoeae"
+      fi
     elif [[ ${predicted_taxon} == *"Salmonella"* ]]; then 
       merlin_tag="Salmonella"
     elif [[ ${predicted_taxon} == *"Staphylococcus"* ]]; then 

--- a/tasks/taxon_id/task_gambit.wdl
+++ b/tasks/taxon_id/task_gambit.wdl
@@ -157,6 +157,9 @@ task gambit {
       # if predicted taxon is Neisseria gonorrhoeae, reset merlin_tag to Neisseria gonorrhoeae
       if [[ ${predicted_taxon} == *"Neisseria gonorrhoeae"* ]]; then 
         merlin_tag="Neisseria gonorrhoeae"
+      # if predicted taxon is Neisseria meningitidis, reset merlin_tag to Neisseria meningitidis
+      elif [[ ${predicted_taxon} == *"Neisseria meningitidis"* ]]; then
+        merlin_tag="Neisseria meningitidis"
       fi
     elif [[ ${predicted_taxon} == *"Salmonella"* ]]; then 
       merlin_tag="Salmonella"

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -185,6 +185,17 @@ task export_taxon_tables {
     String? kaptive_ocl_confidence
     File? ngmaster_tsv
     String? ngmaster_version
+    String? ngmaster_ngmast_sequence_type
+    String? ngmaster_ngmast_porB_allele
+    String? ngmaster_ngmast_tbpB_allele
+    String? ngmaster_ngstar_sequence_type
+    String? ngmaster_ngstar_penA_allele
+    String? ngmaster_ngstar_mtrR_allele
+    String? ngmaster_ngstar_porB_allele
+    String? ngmaster_ngstar_ponA_allele
+    String? ngmaster_ngstar_gyrA_allele
+    String? ngmaster_ngstar_parC_allele
+    String? ngmaster_ngstar_23S_allele
     File? meningotype_tsv
     String? meningotype_version
     String? meningotype_serogroup
@@ -427,6 +438,17 @@ task export_taxon_tables {
       "kleborate_olocus_confidence": "~{kleborate_olocus_confidence}",
       "ngmaster_tsv": "~{ngmaster_tsv}",
       "ngmaster_version": "~{ngmaster_version}",
+      "ngmaster_ngmast_sequence_type": "~{ngmaster_ngmast_sequence_type}",
+      "ngmaster_ngmast_porB_allele": "~{ngmaster_ngmast_porB_allele}",
+      "ngmaster_ngmast_tbpB_allele": "~{ngmaster_ngmast_tbpB_allele}",
+      "ngmaster_ngstar_sequence_type": "~{ngmaster_ngstar_sequence_type}",
+      "ngmaster_ngstar_penA_allele": "~{ngmaster_ngstar_penA_allele}",
+      "ngmaster_ngstar_mtrR_allele": "~{ngmaster_ngstar_mtrR_allele}",
+      "ngmaster_ngstar_porB_allele": "~{ngmaster_ngstar_porB_allele}",
+      "ngmaster_ngstar_ponA_allele": "~{ngmaster_ngstar_ponA_allele}",
+      "ngmaster_ngstar_gyrA_allele": "~{ngmaster_ngstar_gyrA_allele}",
+      "ngmaster_ngstar_parC_allele": "~{ngmaster_ngstar_parC_allele}",
+      "ngmaster_ngstar_23S_allele": "~{ngmaster_ngstar_23S_allele}",
       "meningotype_tsv": "~{meningotype_tsv}",
       "meningotype_version": "~{meningotype_version}",
       "meningotype_serogroup": "~{meningotype_serogroup}",

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -188,6 +188,13 @@ task export_taxon_tables {
     File? meningotype_tsv
     String? meningotype_version
     String? meningotype_serogroup
+    String? meningotype_PorA
+    String? meningotype_FetA
+    String? meningotype_PorB
+    String? meningotype_fHbp
+    String? meningotype_NHBA
+    String? meningotype_NadA
+    String? meningotype_BAST
     File? abricate_abaum_plasmid_tsv
     String? abricate_abaum_plasmid_type_genes
     String? abricate_database
@@ -423,6 +430,13 @@ task export_taxon_tables {
       "meningotype_tsv": "~{meningotype_tsv}",
       "meningotype_version": "~{meningotype_version}",
       "meningotype_serogroup": "~{meningotype_serogroup}",
+      "meningotype_PorA": "~{meningotype_PorA}",
+      "meningotype_FetA": "~{meningotype_FetA}",
+      "meningotype_PorB": "~{meningotype_PorB}",
+      "meningotype_fHbp": "~{meningotype_fHbp}",
+      "meningotype_NHBA": "~{meningotype_NHBA}",
+      "meningotype_NadA": "~{meningotype_NadA}",
+      "meningotype_BAST": "~{meningotype_BAST}",
       "kaptive_version": "~{kaptive_version}",
       "kaptive_output_file_k": "~{kaptive_output_file_k}",
       "kaptive_output_file_oc": "~{kaptive_output_file_oc}",

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -187,6 +187,7 @@ task export_taxon_tables {
     String? ngmaster_version
     File? meningotype_tsv
     String? meningotype_version
+    String? meningotype_serogroup
     File? abricate_abaum_plasmid_tsv
     String? abricate_abaum_plasmid_type_genes
     String? abricate_database
@@ -421,6 +422,7 @@ task export_taxon_tables {
       "ngmaster_version": "~{ngmaster_version}",
       "meningotype_tsv": "~{meningotype_tsv}",
       "meningotype_version": "~{meningotype_version}",
+      "meningotype_serogroup": "~{meningotype_serogroup}",
       "kaptive_version": "~{kaptive_version}",
       "kaptive_output_file_k": "~{kaptive_output_file_k}",
       "kaptive_output_file_oc": "~{kaptive_output_file_oc}",

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -185,6 +185,8 @@ task export_taxon_tables {
     String? kaptive_ocl_confidence
     File? ngmaster_tsv
     String? ngmaster_version
+    File? meningotype_tsv
+    String? meningotype_version
     File? abricate_abaum_plasmid_tsv
     String? abricate_abaum_plasmid_type_genes
     String? abricate_database
@@ -417,6 +419,8 @@ task export_taxon_tables {
       "kleborate_olocus_confidence": "~{kleborate_olocus_confidence}",
       "ngmaster_tsv": "~{ngmaster_tsv}",
       "ngmaster_version": "~{ngmaster_version}",
+      "meningotype_tsv": "~{meningotype_tsv}",
+      "meningotype_version": "~{meningotype_version}",
       "kaptive_version": "~{kaptive_version}",
       "kaptive_output_file_k": "~{kaptive_output_file_k}",
       "kaptive_output_file_oc": "~{kaptive_output_file_oc}",

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -183,6 +183,8 @@ task export_taxon_tables {
     String? kaptive_kl_confidence
     String? kaptive_oc_locus
     String? kaptive_ocl_confidence
+    File? ngmaster_tsv
+    String? ngmaster_version
     File? abricate_abaum_plasmid_tsv
     String? abricate_abaum_plasmid_type_genes
     String? abricate_database
@@ -413,6 +415,8 @@ task export_taxon_tables {
       "kleborate_otype": "~{kleborate_otype}",
       "kleborate_klocus_confidence": "~{kleborate_klocus_confidence}",
       "kleborate_olocus_confidence": "~{kleborate_olocus_confidence}",
+      "ngmaster_tsv": "~{ngmaster_tsv}",
+      "ngmaster_version": "!{ngmaster_version}",
       "kaptive_version": "~{kaptive_version}",
       "kaptive_output_file_k": "~{kaptive_output_file_k}",
       "kaptive_output_file_oc": "~{kaptive_output_file_oc}",

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -416,7 +416,7 @@ task export_taxon_tables {
       "kleborate_klocus_confidence": "~{kleborate_klocus_confidence}",
       "kleborate_olocus_confidence": "~{kleborate_olocus_confidence}",
       "ngmaster_tsv": "~{ngmaster_tsv}",
-      "ngmaster_version": "!{ngmaster_version}",
+      "ngmaster_version": "~{ngmaster_version}",
       "kaptive_version": "~{kaptive_version}",
       "kaptive_output_file_k": "~{kaptive_output_file_k}",
       "kaptive_output_file_oc": "~{kaptive_output_file_oc}",

--- a/tests/workflows/test_wf_theiaprok_illumina_pe.yml
+++ b/tests/workflows/test_wf_theiaprok_illumina_pe.yml
@@ -107,7 +107,7 @@
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/test_1.clean.fastq.gz
     - path: miniwdl_run/call-clean_check_reads/work/_miniwdl_inputs/0/test_2.clean.fastq.gz
     - path: miniwdl_run/call-gambit/command
-      md5sum: 0fd32da5d38ab57cdb7eb6ef87756cc1
+      md5sum: 5e6b3458a9dfa1c6f3a04af66f40f746
     - path: miniwdl_run/call-gambit/inputs.json
       contains: ["assembly", "fasta", "samplename", "test"]
     - path: miniwdl_run/call-gambit/outputs.json

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -298,6 +298,13 @@ workflow merlin_magic {
   File? meningotype_tsv = meningotype.meningotype_tsv
   String? meningotype_version = meningotype.meningotype_version
   String? meningotype_serogroup = meningotype.meningotype_serogroup
+  String? meningotype_PorA = meningotype.meningotype_PorA
+  String? meningotype_FetA = meningotype.meningotype_FetA
+  String? meningotype_PorB = meningotype.meningotype_PorB
+  String? meningotype_fHbp = meningotype.meningotype_fHbp
+  String? meningotype_NHBA = meningotype.meningotype_NHBA
+  String? meningotype_NadA = meningotype.meningotype_NadA
+  String? meningotype_BAST = meningotype.meningotype_BAST
   # Acinetobacter Typing
   File? kaptive_output_file_k = kaptive.kaptive_output_file_k
   File? kaptive_output_file_oc = kaptive.kaptive_output_file_oc

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -297,6 +297,7 @@ workflow merlin_magic {
   # Neisseria meningitidis Typing
   File? meningotype_tsv = meningotype.meningotype_tsv
   String? meningotype_version = meningotype.meningotype_version
+  String? meningotype_serogroup = meningotype.meningotype_serogroup
   # Acinetobacter Typing
   File? kaptive_output_file_k = kaptive.kaptive_output_file_k
   File? kaptive_output_file_oc = kaptive.kaptive_output_file_oc

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -13,6 +13,7 @@ import "../tasks/species_typing/task_tbprofiler.wdl" as tbprofiler
 import "../tasks/species_typing/task_legsta.wdl" as legsta
 import "../tasks/species_typing/task_genotyphi.wdl" as genotyphi
 import "../tasks/species_typing/task_kaptive.wdl" as kaptive
+import "../tasks/species_typing/task_ngmaster.wdl" as ngmaster_task
 import "../tasks/species_typing/task_seroba.wdl" as seroba
 import "../tasks/species_typing/task_pbptyper.wdl" as pbptyper
 import "../tasks/species_typing/task_poppunk_streppneumo.wdl" as poppunk_spneumo
@@ -129,6 +130,13 @@ workflow merlin_magic {
   }
   if (merlin_tag == "Klebsiella") {
     call kleborate.kleborate {
+      input:
+        assembly = assembly,
+        samplename = samplename
+    }
+  }
+  if (merlin_tag == "Neisseria gonorrhoeae") {
+    call ngmaster_task.ngmaster {
       input:
         assembly = assembly,
         samplename = samplename
@@ -275,6 +283,9 @@ workflow merlin_magic {
   String? kleborate_otype = kleborate.kleborate_otype
   String? kleborate_klocus_confidence = kleborate.kleborate_klocus_confidence
   String? kleborate_olocus_confidence = kleborate.kleborate_olocus_confidence
+  # Neisseria gonorrhoeae Typing
+  File? ngmaster_tsv = ngmaster.ngmaster_tsv
+  String? ngmaster_version = ngmaster.ngmaster_version
   # Acinetobacter Typing
   File? kaptive_output_file_k = kaptive.kaptive_output_file_k
   File? kaptive_output_file_oc = kaptive.kaptive_output_file_oc

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -14,6 +14,7 @@ import "../tasks/species_typing/task_legsta.wdl" as legsta
 import "../tasks/species_typing/task_genotyphi.wdl" as genotyphi
 import "../tasks/species_typing/task_kaptive.wdl" as kaptive
 import "../tasks/species_typing/task_ngmaster.wdl" as ngmaster_task
+import "../tasks/species_typing/task_meningotype.wdl" as meningotype_task
 import "../tasks/species_typing/task_seroba.wdl" as seroba
 import "../tasks/species_typing/task_pbptyper.wdl" as pbptyper
 import "../tasks/species_typing/task_poppunk_streppneumo.wdl" as poppunk_spneumo
@@ -137,6 +138,13 @@ workflow merlin_magic {
   }
   if (merlin_tag == "Neisseria gonorrhoeae") {
     call ngmaster_task.ngmaster {
+      input:
+        assembly = assembly,
+        samplename = samplename
+    }
+  }
+  if (merlin_tag == "Neisseria meningitidis") {
+    call meningotype_task.meningotype {
       input:
         assembly = assembly,
         samplename = samplename
@@ -286,6 +294,9 @@ workflow merlin_magic {
   # Neisseria gonorrhoeae Typing
   File? ngmaster_tsv = ngmaster.ngmaster_tsv
   String? ngmaster_version = ngmaster.ngmaster_version
+  # Neisseria meningitidis Typing
+  File? meningotype_tsv = meningotype.meningotype_tsv
+  String? meningotype_version = meningotype.meningotype_version
   # Acinetobacter Typing
   File? kaptive_output_file_k = kaptive.kaptive_output_file_k
   File? kaptive_output_file_oc = kaptive.kaptive_output_file_oc

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -294,6 +294,17 @@ workflow merlin_magic {
   # Neisseria gonorrhoeae Typing
   File? ngmaster_tsv = ngmaster.ngmaster_tsv
   String? ngmaster_version = ngmaster.ngmaster_version
+  String? ngmaster_ngmast_sequence_type = ngmaster.ngmaster_ngmast_sequence_type
+  String? ngmaster_ngmast_porB_allele = ngmaster.ngmaster_ngmast_porB_allele
+  String? ngmaster_ngmast_tbpB_allele = ngmaster.ngmaster_ngmast_tbpB_allele
+  String? ngmaster_ngstar_sequence_type = ngmaster.ngmaster_ngstar_sequence_type
+  String? ngmaster_ngstar_penA_allele = ngmaster.ngmaster_ngstar_penA_allele
+  String? ngmaster_ngstar_mtrR_allele = ngmaster.ngmaster_ngstar_mtrR_allele
+  String? ngmaster_ngstar_porB_allele = ngmaster.ngmaster_ngstar_porB_allele
+  String? ngmaster_ngstar_ponA_allele = ngmaster.ngmaster_ngstar_ponA_allele
+  String? ngmaster_ngstar_gyrA_allele = ngmaster.ngmaster_ngstar_gyrA_allele
+  String? ngmaster_ngstar_parC_allele = ngmaster.ngmaster_ngstar_parC_allele
+  String? ngmaster_ngstar_23S_allele = ngmaster.ngmaster_ngstar_23S_allele
   # Neisseria meningitidis Typing
   File? meningotype_tsv = meningotype.meningotype_tsv
   String? meningotype_version = meningotype.meningotype_version

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -661,6 +661,13 @@ workflow theiaprok_illumina_pe {
     File? meningotype_tsv = merlin_magic.meningotype_tsv
     String? meningotype_version = merlin_magic.meningotype_version
     String? meningotype_serogroup = merlin_magic.meningotype_serogroup
+    String? meningotype_PorA = merlin_magic.meningotype_PorA
+    String? meningotype_FetA = merlin_magic.meningotype_FetA
+    String? meningotype_PorB = merlin_magic.meningotype_PorB
+    String? meningotype_fHbp = merlin_magic.meningotype_fHbp
+    String? meningotype_NHBA = merlin_magic.meningotype_NHBA
+    String? meningotype_NadA = merlin_magic.meningotype_NadA
+    String? meningotype_BAST = merlin_magic.meningotype_BAST
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -654,6 +654,9 @@ workflow theiaprok_illumina_pe {
     String? kleborate_otype = merlin_magic.kleborate_otype
     String? kleborate_klocus_confidence = merlin_magic.kleborate_klocus_confidence
     String? kleborate_olocus_confidence = merlin_magic.kleborate_olocus_confidence
+    # Neisseria gonorrhoeae Typing
+    File? ngmaster_tsv = merlin_magic.ngmaster_tsv
+    String? ngmaster_version = merlin_magic.ngmaster_version
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -374,6 +374,29 @@ workflow theiaprok_illumina_pe {
             kleborate_otype = merlin_magic.kleborate_otype,
             kleborate_klocus_confidence = merlin_magic.kleborate_klocus_confidence,
             kleborate_olocus_confidence = merlin_magic.kleborate_olocus_confidence,
+            ngmaster_tsv = merlin_magic.ngmaster_tsv,
+            ngmaster_version = merlin_magic.ngmaster_version,
+            ngmaster_ngmast_sequence_type = merlin_magic.ngmaster_ngmast_sequence_type,
+            ngmaster_ngmast_porB_allele = merlin_magic.ngmaster_ngmast_porB_allele,
+            ngmaster_ngmast_tbpB_allele = merlin_magic.ngmaster_ngmast_tbpB_allele,
+            ngmaster_ngstar_sequence_type = merlin_magic.ngmaster_ngstar_sequence_type,
+            ngmaster_ngstar_penA_allele = merlin_magic.ngmaster_ngstar_penA_allele,
+            ngmaster_ngstar_mtrR_allele = merlin_magic.ngmaster_ngstar_mtrR_allele,
+            ngmaster_ngstar_porB_allele = merlin_magic.ngmaster_ngstar_porB_allele,
+            ngmaster_ngstar_ponA_allele = merlin_magic.ngmaster_ngstar_ponA_allele,
+            ngmaster_ngstar_gyrA_allele = merlin_magic.ngmaster_ngstar_gyrA_allele,
+            ngmaster_ngstar_parC_allele = merlin_magic.ngmaster_ngstar_parC_allele,
+            ngmaster_ngstar_23S_allele = merlin_magic.ngmaster_ngstar_23S_allele,
+            meningotype_tsv = merlin_magic.meningotype_tsv,
+            meningotype_version = merlin_magic.meningotype_version,
+            meningotype_serogroup = merlin_magic.meningotype_serogroup,
+            meningotype_PorA = merlin_magic.meningotype_PorA,
+            meningotype_FetA = merlin_magic.meningotype_FetA,
+            meningotype_PorB = merlin_magic.meningotype_PorB,
+            meningotype_fHbp = merlin_magic.meningotype_fHbp,
+            meningotype_NHBA = merlin_magic.meningotype_NHBA,
+            meningotype_NadA = merlin_magic.meningotype_NadA,
+            meningotype_BAST = merlin_magic.meningotype_BAST,
             kaptive_output_file_k = merlin_magic.kaptive_output_file_k,
             kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc,
             kaptive_version = merlin_magic.kaptive_version,
@@ -657,6 +680,17 @@ workflow theiaprok_illumina_pe {
     # Neisseria gonorrhoeae Typing
     File? ngmaster_tsv = merlin_magic.ngmaster_tsv
     String? ngmaster_version = merlin_magic.ngmaster_version
+    String? ngmaster_ngmast_sequence_type = merlin_magic.ngmaster_ngmast_sequence_type
+    String? ngmaster_ngmast_porB_allele = merlin_magic.ngmaster_ngmast_porB_allele
+    String? ngmaster_ngmast_tbpB_allele = merlin_magic.ngmaster_ngmast_tbpB_allele
+    String? ngmaster_ngstar_sequence_type = merlin_magic.ngmaster_ngstar_sequence_type
+    String? ngmaster_ngstar_penA_allele = merlin_magic.ngmaster_ngstar_penA_allele
+    String? ngmaster_ngstar_mtrR_allele = merlin_magic.ngmaster_ngstar_mtrR_allele
+    String? ngmaster_ngstar_porB_allele = merlin_magic.ngmaster_ngstar_porB_allele
+    String? ngmaster_ngstar_ponA_allele = merlin_magic.ngmaster_ngstar_ponA_allele
+    String? ngmaster_ngstar_gyrA_allele = merlin_magic.ngmaster_ngstar_gyrA_allele
+    String? ngmaster_ngstar_parC_allele = merlin_magic.ngmaster_ngstar_parC_allele
+    String? ngmaster_ngstar_23S_allele = merlin_magic.ngmaster_ngstar_23S_allele
     # Neisseria meningitidis Typing
     File? meningotype_tsv = merlin_magic.meningotype_tsv
     String? meningotype_version = merlin_magic.meningotype_version

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -660,6 +660,7 @@ workflow theiaprok_illumina_pe {
     # Neisseria meningitidis Typing
     File? meningotype_tsv = merlin_magic.meningotype_tsv
     String? meningotype_version = merlin_magic.meningotype_version
+    String? meningotype_serogroup = merlin_magic.meningotype_serogroup
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -657,6 +657,9 @@ workflow theiaprok_illumina_pe {
     # Neisseria gonorrhoeae Typing
     File? ngmaster_tsv = merlin_magic.ngmaster_tsv
     String? ngmaster_version = merlin_magic.ngmaster_version
+    # Neisseria meningitidis Typing
+    File? meningotype_tsv = merlin_magic.meningotype_tsv
+    String? meningotype_version = merlin_magic.meningotype_version
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -587,6 +587,13 @@ workflow theiaprok_illumina_se {
     File? meningotype_tsv = merlin_magic.meningotype_tsv
     String? meningotype_version = merlin_magic.meningotype_version
     String? meningotype_serogroup = merlin_magic.meningotype_serogroup
+    String? meningotype_PorA = merlin_magic.meningotype_PorA
+    String? meningotype_FetA = merlin_magic.meningotype_FetA
+    String? meningotype_PorB = merlin_magic.meningotype_PorB
+    String? meningotype_fHbp = merlin_magic.meningotype_fHbp
+    String? meningotype_NHBA = merlin_magic.meningotype_NHBA
+    String? meningotype_NadA = merlin_magic.meningotype_NadA
+    String? meningotype_BAST = merlin_magic.meningotype_BAST
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -322,6 +322,29 @@ workflow theiaprok_illumina_se {
             kleborate_otype = merlin_magic.kleborate_otype,
             kleborate_klocus_confidence = merlin_magic.kleborate_klocus_confidence,
             kleborate_olocus_confidence = merlin_magic.kleborate_olocus_confidence,
+            ngmaster_tsv = merlin_magic.ngmaster_tsv,
+            ngmaster_version = merlin_magic.ngmaster_version,
+            ngmaster_ngmast_sequence_type = merlin_magic.ngmaster_ngmast_sequence_type,
+            ngmaster_ngmast_porB_allele = merlin_magic.ngmaster_ngmast_porB_allele,
+            ngmaster_ngmast_tbpB_allele = merlin_magic.ngmaster_ngmast_tbpB_allele,
+            ngmaster_ngstar_sequence_type = merlin_magic.ngmaster_ngstar_sequence_type,
+            ngmaster_ngstar_penA_allele = merlin_magic.ngmaster_ngstar_penA_allele,
+            ngmaster_ngstar_mtrR_allele = merlin_magic.ngmaster_ngstar_mtrR_allele,
+            ngmaster_ngstar_porB_allele = merlin_magic.ngmaster_ngstar_porB_allele,
+            ngmaster_ngstar_ponA_allele = merlin_magic.ngmaster_ngstar_ponA_allele,
+            ngmaster_ngstar_gyrA_allele = merlin_magic.ngmaster_ngstar_gyrA_allele,
+            ngmaster_ngstar_parC_allele = merlin_magic.ngmaster_ngstar_parC_allele,
+            ngmaster_ngstar_23S_allele = merlin_magic.ngmaster_ngstar_23S_allele,
+            meningotype_tsv = merlin_magic.meningotype_tsv,
+            meningotype_version = merlin_magic.meningotype_version,
+            meningotype_serogroup = merlin_magic.meningotype_serogroup,
+            meningotype_PorA = merlin_magic.meningotype_PorA,
+            meningotype_FetA = merlin_magic.meningotype_FetA,
+            meningotype_PorB = merlin_magic.meningotype_PorB,
+            meningotype_fHbp = merlin_magic.meningotype_fHbp,
+            meningotype_NHBA = merlin_magic.meningotype_NHBA,
+            meningotype_NadA = merlin_magic.meningotype_NadA,
+            meningotype_BAST = merlin_magic.meningotype_BAST,
             kaptive_output_file_k = merlin_magic.kaptive_output_file_k,
             kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc,
             kaptive_version = merlin_magic.kaptive_version,
@@ -583,6 +606,17 @@ workflow theiaprok_illumina_se {
     # Neisseria gonorrhoeae Typing
     File? ngmaster_tsv = merlin_magic.ngmaster_tsv
     String? ngmaster_version = merlin_magic.ngmaster_version
+    String? ngmaster_ngmast_sequence_type = merlin_magic.ngmaster_ngmast_sequence_type
+    String? ngmaster_ngmast_porB_allele = merlin_magic.ngmaster_ngmast_porB_allele
+    String? ngmaster_ngmast_tbpB_allele = merlin_magic.ngmaster_ngmast_tbpB_allele
+    String? ngmaster_ngstar_sequence_type = merlin_magic.ngmaster_ngstar_sequence_type
+    String? ngmaster_ngstar_penA_allele = merlin_magic.ngmaster_ngstar_penA_allele
+    String? ngmaster_ngstar_mtrR_allele = merlin_magic.ngmaster_ngstar_mtrR_allele
+    String? ngmaster_ngstar_porB_allele = merlin_magic.ngmaster_ngstar_porB_allele
+    String? ngmaster_ngstar_ponA_allele = merlin_magic.ngmaster_ngstar_ponA_allele
+    String? ngmaster_ngstar_gyrA_allele = merlin_magic.ngmaster_ngstar_gyrA_allele
+    String? ngmaster_ngstar_parC_allele = merlin_magic.ngmaster_ngstar_parC_allele
+    String? ngmaster_ngstar_23S_allele = merlin_magic.ngmaster_ngstar_23S_allele
     # Neisseria meningitidis Typing
     File? meningotype_tsv = merlin_magic.meningotype_tsv
     String? meningotype_version = merlin_magic.meningotype_version

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -580,6 +580,12 @@ workflow theiaprok_illumina_se {
     String? kleborate_otype = merlin_magic.kleborate_otype
     String? kleborate_klocus_confidence = merlin_magic.kleborate_klocus_confidence
     String? kleborate_olocus_confidence = merlin_magic.kleborate_olocus_confidence
+    # Neisseria gonorrhoeae Typing
+    File? ngmaster_tsv = merlin_magic.ngmaster_tsv
+    String? ngmaster_version = merlin_magic.ngmaster_version
+    # Neisseria meningitidis Typing
+    File? meningotype_tsv = merlin_magic.meningotype_tsv
+    String? meningotype_version = merlin_magic.meningotype_version
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -586,6 +586,7 @@ workflow theiaprok_illumina_se {
     # Neisseria meningitidis Typing
     File? meningotype_tsv = merlin_magic.meningotype_tsv
     String? meningotype_version = merlin_magic.meningotype_version
+    String? meningotype_serogroup = merlin_magic.meningotype_serogroup
     # Acinetobacter Typing
     File? kaptive_output_file_k = merlin_magic.kaptive_output_file_k
     File? kaptive_output_file_oc = merlin_magic.kaptive_output_file_oc


### PR DESCRIPTION
~~Setting as a draft until testing in Terra is complete and when `staphb/ngmaster:1.0.0` docker image is available~~

staphb docker image is available `staphb/ngmaster:1.0.0`, just doing one final test in Terra with new docker image

This PR:

- alters the meningotype task (for N. meningitidis):
  - by default run all typing options (except `mlst` which is done via `ts_mlst` task which uses more up-to-date dbs)
  - produce new String outputs for the serogroup and each allele number
  - runtime now uses `cpu` input variable
  - removed optional inputs for toggling various typing. We want all to run all the time (except mlst)
- alters ngmaster task (for N. gonnorhoeae):
  - docker default is `kapsakcj/ngmaster:1.0.0`, need to change this to `staphb/ngmaster:1.0.0` when available
  - altered output TSV filename to be more descriptive
  - added code to parse output TSV for MLSequence Types from 2 schemes (NG-MAST and NG-STAR). Additionally parsing allele numbers that correspond w each scheme.
  - added numerous String outputs for each MLST and allele numbers
  - runtime now uses `cpu` input variable
- task_gambit.wdl edited to designate 2 new `merlin_tag`'s: `Neisseria gonorrhoeae` and `Neisseria meningitidis`
- export_taxon_tables task edited to accept new inputs from ngmaster & meningotype tasks
- `wf_merlin_magic.wdl` edited to run:
  - `ngmaster` when merlin_tag is set to `Neisseria gonorrhoeae`
  - `meningotype` when merlin_tag is set to `Neisseria meningitidis`
  - all new outputs added to workflow outputs
- Both `workflows/wf_theiaprok_illumina_pe.wdl` and `workflows/wf_theiaprok_illumina_se.wdl` were edited to have new ngmaster & meningotype outputs
  - also added new outputs as inputs for export_taxon_tables task

Testing:

- [x] Illumina_PE on both species - [Successful Terra workflow (albeit with kapsakcj/ngmaster:1.0.0)](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/85980f46-0bee-4938-9912-9fb26dc0982e); will add link to second test w staphb/ngmaster:1.0.0 docker image soon)
- [x] Illumina_PE - [Successful Terra workflow N. gonnorhoeae with updated `staphb/ngmster:1.0.0` docker image](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/7b5d155e-9759-4814-8ba7-ea7ba24ef781)
- [x] Illumina_SE on both species- [Successful Terra workflow](https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/e35f349f-57b3-4ab2-a19a-d065d5cd1f51)

CC @cimendes 