### PR TITLE
New output columns from TBProfiler Task

### DIFF
--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -6,14 +6,16 @@ task tbprofiler {
     File read1
     File? read2
     String samplename
-    String tbprofiler_docker_image = "staphb/tbprofiler:4.3.0"
+    String tbprofiler_docker_image = "staphb/tbprofiler:4.4.2"
     Int disk_size = 100
-    String? mapper = "bwa"
-    String? caller = "bcftools"
-    Int? min_depth = 10
-    Float? min_af = 0.1
-    Float? min_af_pred = 0.1
-    Int? cov_frac_threshold = 1
+    String mapper = "bwa"
+    String caller = "bcftools"
+    Int min_depth = 10
+    Float min_af = 0.1
+    Float min_af_pred = 0.1
+    Int cov_frac_threshold = 1
+    Boolean tbprofiler_additional_outputs = true
+    String output_seq_method_type = "WGS"
   }
   command <<<
     # update TBDB
@@ -30,7 +32,7 @@ task tbprofiler {
       INPUT_READS="-1 ~{read1} -2 ~{read2}"
     fi
 
-    # Run Kleborate on the input assembly with the --all flag and output with samplename prefix
+    # Run tb-profiler on the input reads with samplename prefix
     tb-profiler profile \
       ${INPUT_READS} \
       --prefix ~{samplename} \
@@ -45,6 +47,13 @@ task tbprofiler {
 
     #Collate results
     tb-profiler collate --prefix ~{samplename}
+
+    # transform boolean tbprofiler_additional_outputs into string for python comparison
+    if ~{tbprofiler_additional_outputs}; then
+      export tbprofiler_additional_outputs="true"
+    else 
+      export tbprofiler_additional_outputs="false"
+    fi
 
     python3 <<CODE
     import csv
@@ -75,6 +84,52 @@ task tbprofiler {
             res_genes.append(tsv_dict[i])
         res_genes_string=';'.join(res_genes)
         Resistance_Genes.write(res_genes_string)
+    
+    import json
+    import os
+    if (os.environ["tbprofiler_additional_outputs"] == "true"):
+
+      gene_name = []
+      locus_tag = []
+      variant_substitutions = []
+
+      with open("./results/~{samplename}.results.json") as results_json_fh:
+        results_json = json.load(results_json_fh)
+        for dr_variant in results_json["dr_variants"]:  # reported mutation by tb-profiler, all confering resistance
+          gene_name.append(dr_variant["gene"])
+          locus_tag.append(dr_variant["locus_tag"])  
+          variant_substitutions.append(dr_variant["type"] + ":" + dr_variant["nucleotide_change"] + "(" + dr_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
+        
+        for other_variant in results_json["other_variants"]:  # mutations not reported by tb-profiler
+          if other_variant["type"] != "synonymous_variant":
+            if other_variant["gene"] == "katG" or other_variant["gene"] == "pncA":  # hardcoded for two genes of interest that are reported to always confer resistance when mutated
+              gene_name.append(other_variant["gene"])
+              locus_tag.append(other_variant["locus_tag"])  
+              variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
+            else:
+              if other_variant["annotation"]:
+                for annotation in other_variant["annotation"]:
+                  if annotation["who_confidence"] != "Not assoc w R":
+                    gene_name.append(other_variant["gene"])
+                    locus_tag.append(other_variant["locus_tag"])  
+                    variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
+        
+        with open("GENE_NAME", "wt") as gene_name_fh:
+          gene_name_fh.write(','.join(gene_name))
+        
+        with open("LOCUS_TAG", "wt") as locus_tag_fh:
+          locus_tag_fh.write(','.join(locus_tag))
+        
+        with open("VARIANT_SUBSTITUTIONS", "wt") as variant_substitutions_fh:
+          variant_substitutions_fh.write(','.join(variant_substitutions))
+        
+        with open("OUTPUT_SEQ_METHOD_TYPE", "wt") as output_seq_method_type_fh:
+          output_seq_method_type_fh.write("~{output_seq_method_type}")
+
+        # file to be ingested into CDPH LIMS system
+        with open("tbprofiler_additional_outputs.csv", "wt") as additional_outputs_csv:
+          additional_outputs_csv.write("tbprofiler_gene_name,tbprofiler_locus_tag,tbprofiler_locus_tag,tbprofiler_variant_substitutions,tbprofiler_output_seq_method_type\n")
+          additional_outputs_csv.write(";".join(gene_name) + "," + ";".join(locus_tag) + "," + ";".join(variant_substitutions) + ',' + "~{output_seq_method_type}")
     CODE
   >>>
   output {
@@ -89,6 +144,11 @@ task tbprofiler {
     String tbprofiler_num_dr_variants = read_string("NUM_DR_VARIANTS")
     String tbprofiler_num_other_variants = read_string("NUM_OTHER_VARIANTS")
     String tbprofiler_resistance_genes = read_string("RESISTANCE_GENES")
+    File? tbprofiler_additional_outputs_csv = "tbprofiler_additional_outputs.csv"
+    String? tbprofiler_gene_name = read_string("GENE_NAME")
+    String? tbprofiler_locus_tag = read_string("LOCUS_TAG")
+    String? tbprofiler_variant_substitutions = read_string("VARIANT_SUBSTITUTIONS")
+    String? tbprofiler_output_seq_method_type = read_string("OUTPUT_SEQ_METHOD_TYPE")
   }
   runtime {
     docker: "~{tbprofiler_docker_image}"
@@ -96,7 +156,7 @@ task tbprofiler {
     cpu: 8
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 3
+    maxRetries: 0
   }
 }
 
@@ -107,12 +167,12 @@ task tbprofiler_ont {
     String samplename
     String tbprofiler_docker_image = "staphb/tbprofiler:4.3.0"
     Int disk_size = 100
-    String? mapper = "bwa"
-    String? caller = "bcftools"
-    Int? min_depth = 10
-    Float? min_af = 0.1
-    Float? min_af_pred = 0.1
-    Int? cov_frac_threshold = 1
+    String mapper = "bwa"
+    String caller = "bcftools"
+    Int min_depth = 10
+    Float min_af = 0.1
+    Float min_af_pred = 0.1
+    Int cov_frac_threshold = 1
   }
   command <<<
     # update TBDB

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -356,11 +356,23 @@ task tbprofiler_ont {
         # laboratorian report
         with open("tbprofiler_laboratorian_report.csv", "wt") as report_fh:
           report_fh.write("tbprofiler_gene_name,tbprofiler_locus_tag,tbprofiler_variant_substitutions,confidence,depth,frequency,warning\n")
+          
           for i in range(0, len(gene_name)):
-            if not depth[i]:  # for cases when depth is null, it gets converted to 0
-              depth[i] = 0
-            warning = "Low depth coverage" if  depth[i] < int('~{min_depth}') else "" # warning when coverage is lower than the defined 'min_depth' times
-            report_fh.write(gene_name[i] + ',' + locus_tag[i] + ',' + variant_substitutions[i] + ',' + confidence[i] + ',' + str(depth[i]) + ',' + str(frequency[i]) + ',' + warning + '\n')
+          
+            warning = []
+            if not depth[i]:  # for cases when depth is null
+              depth[i] = "NA"  # Deletion instead of value
+              warning.append("Deletion")
+            else:
+              if depth[i] < int('~{min_depth}'): # warning when coverage is lower than the defined 'min_depth' times
+                warning.append("Low depth coverage") 
+            if not frequency[i]:
+              warning.append("No frequency")
+            else:
+              if frequency[i] < 0.05: # warning when frequency is lower than 5%
+                warning.append("Low frequency") 
+
+            report_fh.write(gene_name[i] + ',' + locus_tag[i] + ',' + variant_substitutions[i] + ',' + confidence[i] + ',' + str(depth[i]) + ',' + str(frequency[i]) + ',' + ';'.join(warning) + '\n')
 
     CODE
   >>>

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -6,6 +6,8 @@ task tbprofiler {
     File read1
     File? read2
     String samplename
+    Boolean tbprofiler_additional_outputs
+    String output_seq_method_type
     String tbprofiler_docker_image = "staphb/tbprofiler:4.4.2"
     Int disk_size = 100
     String mapper = "bwa"
@@ -14,8 +16,6 @@ task tbprofiler {
     Float min_af = 0.1
     Float min_af_pred = 0.1
     Int cov_frac_threshold = 1
-    Boolean tbprofiler_additional_outputs = false
-    String output_seq_method_type = "WGS"
     Int cpu = 8 
   }
   command <<<

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -165,7 +165,7 @@ task tbprofiler_ont {
   input {
     File reads
     String samplename
-    String tbprofiler_docker_image = "staphb/tbprofiler:4.3.0"
+    String tbprofiler_docker_image = "staphb/tbprofiler:4.4.2"
     Int disk_size = 100
     String mapper = "bwa"
     String caller = "bcftools"

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -169,6 +169,8 @@ task tbprofiler_ont {
   input {
     File reads
     String samplename
+    Boolean tbprofiler_additional_outputs
+    String output_seq_method_type
     String tbprofiler_docker_image = "staphb/tbprofiler:4.4.2"
     Int disk_size = 100
     String mapper = "bwa"
@@ -177,8 +179,6 @@ task tbprofiler_ont {
     Float min_af = 0.1
     Float min_af_pred = 0.1
     Int cov_frac_threshold = 1
-    Boolean tbprofiler_additional_outputs = false
-    String output_seq_method_type = "WGS"
     Int cpu = 8
   }
   command <<<

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -109,10 +109,13 @@ task tbprofiler {
           depth.append(dr_variant["depth"])
           frequency.append(dr_variant["freq"])
           if "annotation" in dr_variant:
-            if dr_variant["annotation"][0]["who_confidence"] == "":
+            try:  # sometimes annotation is an empty list
+              if dr_variant["annotation"][0]["who_confidence"] == "":
+                confidence.append("No WHO annotation")
+              else:
+                confidence.append(dr_variant["annotation"][0]["who_confidence"])
+            except:
               confidence.append("No WHO annotation")
-            else:
-              confidence.append(dr_variant["annotation"][0]["who_confidence"])
           else:
             confidence.append("No WHO annotation")
         
@@ -125,10 +128,13 @@ task tbprofiler {
               depth.append(other_variant["depth"])
               frequency.append(other_variant["freq"])
               if "annotation" in other_variant:
-                if other_variant["annotation"][0]["who_confidence"] == "":
+                try:  # sometimes annotation is an empty list
+                  if other_variant["annotation"][0]["who_confidence"] == "":
+                    confidence.append("No WHO annotation")
+                  else:
+                    confidence.append(other_variant["annotation"][0]["who_confidence"])
+                except:
                   confidence.append("No WHO annotation")
-                else:
-                  confidence.append(other_variant["annotation"][0]["who_confidence"])
               else:
                 confidence.append("No WHO annotation")
             else:
@@ -163,6 +169,8 @@ task tbprofiler {
         with open("tbprofiler_laboratorian_report.csv", "wt") as report_fh:
           report_fh.write("tbprofiler_gene_name,tbprofiler_locus_tag,tbprofiler_variant_substitutions,confidence,depth,frequency,warning\n")
           for i in range(0, len(gene_name)):
+            if not depth[i]:  # for cases when depth is null, it gets converted to 0
+              depth[i] = 0
             warning = "Low depth coverage" if  depth[i] < 10 else "" # warning when coverage is lower than 10 times
             report_fh.write(gene_name[i] + ',' + locus_tag[i] + ',' + variant_substitutions[i] + ',' + confidence[i] + ',' + str(depth[i]) + ',' + str(frequency[i]) + ',' + warning + '\n')
 
@@ -193,7 +201,7 @@ task tbprofiler {
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 3 
+    maxRetries: 0 
   }
 }
 

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -14,7 +14,7 @@ task tbprofiler {
     Float min_af = 0.1
     Float min_af_pred = 0.1
     Int cov_frac_threshold = 1
-    Boolean tbprofiler_additional_outputs = true
+    Boolean tbprofiler_additional_outputs = false
     String output_seq_method_type = "WGS"
     Int cpu = 8 
   }
@@ -177,7 +177,7 @@ task tbprofiler_ont {
     Float min_af = 0.1
     Float min_af_pred = 0.1
     Int cov_frac_threshold = 1
-    Boolean tbprofiler_additional_outputs = true
+    Boolean tbprofiler_additional_outputs = false
     String output_seq_method_type = "WGS"
     Int cpu = 8
   }

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -201,7 +201,7 @@ task tbprofiler {
     cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 0 
+    maxRetries: 3 
   }
 }
 

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -106,7 +106,7 @@ task tbprofiler {
         
         for other_variant in results_json["other_variants"]:  # mutations not reported by tb-profiler
           if other_variant["type"] != "synonymous_variant":
-            if other_variant["gene"] == "katG" or other_variant["gene"] == "pncA":  # hardcoded for two genes of interest that are reported to always confer resistance when mutated
+            if other_variant["gene"] == "katG" or other_variant["gene"] == "pncA" or other_variant["gene"] == "rpoB" or other_variant["gene"] == "ethA" or other_variant["gene"] == "gid":  # hardcoded for genes of interest that are reported to always confer resistance when mutated
               gene_name.append(other_variant["gene"])
               locus_tag.append(other_variant["locus_tag"])  
               variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -173,6 +173,8 @@ task tbprofiler_ont {
     Float min_af = 0.1
     Float min_af_pred = 0.1
     Int cov_frac_threshold = 1
+    Boolean tbprofiler_additional_outputs = true
+    String output_seq_method_type = "WGS"
   }
   command <<<
     # update TBDB
@@ -188,6 +190,13 @@ task tbprofiler_ont {
 
     #Collate results
     tb-profiler collate --prefix ~{samplename}
+
+    # transform boolean tbprofiler_additional_outputs into string for python comparison
+    if ~{tbprofiler_additional_outputs}; then
+      export tbprofiler_additional_outputs="true"
+    else 
+      export tbprofiler_additional_outputs="false"
+    fi
 
     python3 <<CODE
     import csv
@@ -218,6 +227,52 @@ task tbprofiler_ont {
             res_genes.append(tsv_dict[i])
         res_genes_string=';'.join(res_genes)
         Resistance_Genes.write(res_genes_string)
+    
+    import json
+    import os
+    if (os.environ["tbprofiler_additional_outputs"] == "true"):
+
+      gene_name = []
+      locus_tag = []
+      variant_substitutions = []
+
+      with open("./results/~{samplename}.results.json") as results_json_fh:
+        results_json = json.load(results_json_fh)
+        for dr_variant in results_json["dr_variants"]:  # reported mutation by tb-profiler, all confering resistance
+          gene_name.append(dr_variant["gene"])
+          locus_tag.append(dr_variant["locus_tag"])  
+          variant_substitutions.append(dr_variant["type"] + ":" + dr_variant["nucleotide_change"] + "(" + dr_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
+        
+        for other_variant in results_json["other_variants"]:  # mutations not reported by tb-profiler
+          if other_variant["type"] != "synonymous_variant":
+            if other_variant["gene"] == "katG" or other_variant["gene"] == "pncA":  # hardcoded for two genes of interest that are reported to always confer resistance when mutated
+              gene_name.append(other_variant["gene"])
+              locus_tag.append(other_variant["locus_tag"])  
+              variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
+            else:
+              if "annotation" in other_variant:  # check if who annotation field is present
+                for annotation in other_variant["annotation"]:
+                  if annotation["who_confidence"] != "Not assoc w R":
+                    gene_name.append(other_variant["gene"])
+                    locus_tag.append(other_variant["locus_tag"])  
+                    variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
+        
+        with open("GENE_NAME", "wt") as gene_name_fh:
+          gene_name_fh.write(','.join(gene_name))
+        
+        with open("LOCUS_TAG", "wt") as locus_tag_fh:
+          locus_tag_fh.write(','.join(locus_tag))
+        
+        with open("VARIANT_SUBSTITUTIONS", "wt") as variant_substitutions_fh:
+          variant_substitutions_fh.write(','.join(variant_substitutions))
+        
+        with open("OUTPUT_SEQ_METHOD_TYPE", "wt") as output_seq_method_type_fh:
+          output_seq_method_type_fh.write("~{output_seq_method_type}")
+
+        # file to be ingested into CDPH LIMS system
+        with open("tbprofiler_additional_outputs.csv", "wt") as additional_outputs_csv:
+          additional_outputs_csv.write("tbprofiler_gene_name,tbprofiler_locus_tag,tbprofiler_variant_substitutions,tbprofiler_output_seq_method_type\n")
+          additional_outputs_csv.write(";".join(gene_name) + "," + ";".join(locus_tag) + "," + ";".join(variant_substitutions) + ',' + "~{output_seq_method_type}")
     CODE
   >>>
   output {
@@ -232,6 +287,11 @@ task tbprofiler_ont {
     String tbprofiler_num_dr_variants = read_string("NUM_DR_VARIANTS")
     String tbprofiler_num_other_variants = read_string("NUM_OTHER_VARIANTS")
     String tbprofiler_resistance_genes = read_string("RESISTANCE_GENES")
+    File? tbprofiler_additional_outputs_csv = "tbprofiler_additional_outputs.csv"
+    String? tbprofiler_gene_name = read_string("GENE_NAME")
+    String? tbprofiler_locus_tag = read_string("LOCUS_TAG")
+    String? tbprofiler_variant_substitutions = read_string("VARIANT_SUBSTITUTIONS")
+    String? tbprofiler_output_seq_method_type = read_string("OUTPUT_SEQ_METHOD_TYPE")
   }
   runtime {
     docker: "~{tbprofiler_docker_image}"

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -48,6 +48,9 @@ task tbprofiler {
     #Collate results
     tb-profiler collate --prefix ~{samplename}
 
+    # touch optional output files because wdl
+    touch GENE_NAME LOCUS_TAG VARIANT_SUBSTITUTIONS OUTPUT_SEQ_METHOD_TYPE
+
     # transform boolean tbprofiler_additional_outputs into string for python comparison
     if ~{tbprofiler_additional_outputs}; then
       export tbprofiler_additional_outputs="true"
@@ -145,10 +148,10 @@ task tbprofiler {
     String tbprofiler_num_other_variants = read_string("NUM_OTHER_VARIANTS")
     String tbprofiler_resistance_genes = read_string("RESISTANCE_GENES")
     File? tbprofiler_additional_outputs_csv = "tbprofiler_additional_outputs.csv"
-    String? tbprofiler_gene_name = read_string("GENE_NAME")
-    String? tbprofiler_locus_tag = read_string("LOCUS_TAG")
-    String? tbprofiler_variant_substitutions = read_string("VARIANT_SUBSTITUTIONS")
-    String? tbprofiler_output_seq_method_type = read_string("OUTPUT_SEQ_METHOD_TYPE")
+    String tbprofiler_gene_name = read_string("GENE_NAME")
+    String tbprofiler_locus_tag = read_string("LOCUS_TAG")
+    String tbprofiler_variant_substitutions = read_string("VARIANT_SUBSTITUTIONS")
+    String tbprofiler_output_seq_method_type = read_string("OUTPUT_SEQ_METHOD_TYPE")
   }
   runtime {
     docker: "~{tbprofiler_docker_image}"
@@ -191,6 +194,9 @@ task tbprofiler_ont {
     #Collate results
     tb-profiler collate --prefix ~{samplename}
 
+    # touch optional output files because wdl
+    touch GENE_NAME LOCUS_TAG VARIANT_SUBSTITUTIONS OUTPUT_SEQ_METHOD_TYPE
+
     # transform boolean tbprofiler_additional_outputs into string for python comparison
     if ~{tbprofiler_additional_outputs}; then
       export tbprofiler_additional_outputs="true"
@@ -288,10 +294,10 @@ task tbprofiler_ont {
     String tbprofiler_num_other_variants = read_string("NUM_OTHER_VARIANTS")
     String tbprofiler_resistance_genes = read_string("RESISTANCE_GENES")
     File? tbprofiler_additional_outputs_csv = "tbprofiler_additional_outputs.csv"
-    String? tbprofiler_gene_name = read_string("GENE_NAME")
-    String? tbprofiler_locus_tag = read_string("LOCUS_TAG")
-    String? tbprofiler_variant_substitutions = read_string("VARIANT_SUBSTITUTIONS")
-    String? tbprofiler_output_seq_method_type = read_string("OUTPUT_SEQ_METHOD_TYPE")
+    String tbprofiler_gene_name = read_string("GENE_NAME")
+    String tbprofiler_locus_tag = read_string("LOCUS_TAG")
+    String tbprofiler_variant_substitutions = read_string("VARIANT_SUBSTITUTIONS")
+    String tbprofiler_output_seq_method_type = read_string("OUTPUT_SEQ_METHOD_TYPE")
   }
   runtime {
     docker: "~{tbprofiler_docker_image}"

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -109,9 +109,12 @@ task tbprofiler {
           depth.append(dr_variant["depth"])
           frequency.append(dr_variant["freq"])
           if "annotation" in dr_variant:
-            confidence.append(dr_variant["annotation"][0]["who_confidence"])
+            if dr_variant["annotation"][0]["who_confidence"] == "":
+              confidence.append("No WHO annotation")
+            else:
+              confidence.append(dr_variant["annotation"][0]["who_confidence"])
           else:
-            confidence.append("no who annotation")
+            confidence.append("No WHO annotation")
         
         for other_variant in results_json["other_variants"]:  # mutations not reported by tb-profiler
           if other_variant["type"] != "synonymous_variant":
@@ -122,13 +125,16 @@ task tbprofiler {
               depth.append(other_variant["depth"])
               frequency.append(other_variant["freq"])
               if "annotation" in other_variant:
-                confidence.append(other_variant["annotation"][0]["who_confidence"])
+                if other_variant["annotation"][0]["who_confidence"] == "":
+                  confidence.append("No WHO annotation")
+                else:
+                  confidence.append(other_variant["annotation"][0]["who_confidence"])
               else:
-                confidence.append("no who annotation")
+                confidence.append("No WHO annotation")
             else:
               if "annotation" in other_variant:  # check if who annotation field is present
                 for annotation in other_variant["annotation"]:
-                  if annotation["who_confidence"] != "Not assoc w R":
+                  if annotation["who_confidence"] != "Not assoc w R" or annotation["who_confidence"] != "":
                     gene_name.append(other_variant["gene"])
                     locus_tag.append(other_variant["locus_tag"])  
                     variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -16,6 +16,7 @@ task tbprofiler {
     Int cov_frac_threshold = 1
     Boolean tbprofiler_additional_outputs = true
     String output_seq_method_type = "WGS"
+    Int cpu = 8 
   }
   command <<<
     # update TBDB
@@ -156,7 +157,7 @@ task tbprofiler {
   runtime {
     docker: "~{tbprofiler_docker_image}"
     memory: "16 GB"
-    cpu: 8
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3
@@ -178,6 +179,7 @@ task tbprofiler_ont {
     Int cov_frac_threshold = 1
     Boolean tbprofiler_additional_outputs = true
     String output_seq_method_type = "WGS"
+    Int cpu = 8
   }
   command <<<
     # update TBDB
@@ -302,7 +304,7 @@ task tbprofiler_ont {
   runtime {
     docker: "~{tbprofiler_docker_image}"
     memory: "16 GB"
-    cpu: 8
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -128,7 +128,7 @@ task tbprofiler {
 
         # file to be ingested into CDPH LIMS system
         with open("tbprofiler_additional_outputs.csv", "wt") as additional_outputs_csv:
-          additional_outputs_csv.write("tbprofiler_gene_name,tbprofiler_locus_tag,tbprofiler_locus_tag,tbprofiler_variant_substitutions,tbprofiler_output_seq_method_type\n")
+          additional_outputs_csv.write("tbprofiler_gene_name,tbprofiler_locus_tag,tbprofiler_variant_substitutions,tbprofiler_output_seq_method_type\n")
           additional_outputs_csv.write(";".join(gene_name) + "," + ";".join(locus_tag) + "," + ";".join(variant_substitutions) + ',' + "~{output_seq_method_type}")
     CODE
   >>>
@@ -156,7 +156,7 @@ task tbprofiler {
     cpu: 8
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
-    maxRetries: 0
+    maxRetries: 3
   }
 }
 

--- a/tasks/species_typing/task_tbprofiler.wdl
+++ b/tasks/species_typing/task_tbprofiler.wdl
@@ -107,7 +107,7 @@ task tbprofiler {
               locus_tag.append(other_variant["locus_tag"])  
               variant_substitutions.append(other_variant["type"] + ":" + other_variant["nucleotide_change"] + "(" + other_variant["protein_change"] + ")")  # mutation_type:nt_sub(aa_sub)
             else:
-              if other_variant["annotation"]:
+              if "annotation" in other_variant:  # check if who annotation field is present
                 for annotation in other_variant["annotation"]:
                   if annotation["who_confidence"] != "Not assoc w R":
                     gene_name.append(other_variant["gene"])

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -198,6 +198,7 @@ task export_taxon_tables {
     String? tbprofiler_dr_type
     String? tbprofiler_resistance_genes
     File? tbprofiler_additional_outputs_csv
+    File? tbprofiler_laboratorian_report_csv
     String? tbprofiler_gene_name
     String? tbprofiler_locus_tag
     String? tbprofiler_variant_substitutions
@@ -445,6 +446,7 @@ task export_taxon_tables {
       "tbprofiler_dr_type": "~{tbprofiler_dr_type}",
       "tbprofiler_resistance_genes": "~{tbprofiler_resistance_genes}",
       "tbprofiler_additional_outputs_csv": "~{tbprofiler_additional_outputs_csv}",
+      "tbprofiler_laboratorian_report_csv": "~{tbprofiler_laboratorian_report_csv}"
       "tbprofiler_gene_name": "~{tbprofiler_gene_name}",
       "tbprofiler_locus_tag": "~{tbprofiler_locus_tag}",
       "tbprofiler_variant_substitutions": "~{tbprofiler_variant_substitutions}",

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -197,6 +197,11 @@ task export_taxon_tables {
     String? tbprofiler_sub_lineage
     String? tbprofiler_dr_type
     String? tbprofiler_resistance_genes
+    File? tbprofiler_additional_outputs_csv
+    String? tbprofiler_gene_name
+    String? tbprofiler_locus_tag
+    String? tbprofiler_variant_substitutions
+    String? tbprofiler_output_seq_method_type
     File? legsta_results
     String? legsta_predicted_sbt
     String? legsta_version
@@ -439,6 +444,11 @@ task export_taxon_tables {
       "tbprofiler_sub_lineage": "~{tbprofiler_sub_lineage}",
       "tbprofiler_dr_type": "~{tbprofiler_dr_type}",
       "tbprofiler_resistance_genes": "~{tbprofiler_resistance_genes}",
+      "tbprofiler_additional_outputs_csv": "~{tbprofiler_additional_outputs_csv}",
+      "tbprofiler_gene_name": "~{tbprofiler_gene_name}",
+      "tbprofiler_locus_tag": "~{tbprofiler_locus_tag}",
+      "tbprofiler_variant_substitutions": "~{tbprofiler_variant_substitutions}",
+      "tbprofiler_output_seq_method_type": "~{tbprofiler_output_seq_method_type}",
       "amrfinderplus_all_report": "~{amrfinderplus_all_report}",
       "amrfinderplus_amr_report": "~{amrfinderplus_amr_report}",
       "amrfinderplus_stress_report": "~{amrfinderplus_stress_report}",

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -304,6 +304,7 @@ workflow merlin_magic {
   String? tbprofiler_dr_type = tbprofiler.tbprofiler_dr_type
   String? tbprofiler_resistance_genes = tbprofiler.tbprofiler_resistance_genes
   File? tbprofiler_additional_outputs_csv = tbprofiler.tbprofiler_additional_outputs_csv
+  File? tbprofiler_laboratorian_report_csv = tbprofiler.tbprofiler_laboratorian_report_csv
   String? tbprofiler_gene_name = tbprofiler.tbprofiler_gene_name
   String? tbprofiler_locus_tag = tbprofiler.tbprofiler_locus_tag
   String? tbprofiler_variant_substitutions = tbprofiler.tbprofiler_variant_substitutions

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -299,6 +299,11 @@ workflow merlin_magic {
   String? tbprofiler_sub_lineage = tbprofiler.tbprofiler_sub_lineage
   String? tbprofiler_dr_type = tbprofiler.tbprofiler_dr_type
   String? tbprofiler_resistance_genes = tbprofiler.tbprofiler_resistance_genes
+  File? tbprofiler_additional_outputs_csv = tbprofiler.tbprofiler_additional_outputs_csv
+  String? tbprofiler_gene_name = tbprofiler.tbprofiler_gene_name
+  String? tbprofiler_locus_tag = tbprofiler.tbprofiler_locus_tag
+  String? tbprofiler_variant_substitutions = tbprofiler.tbprofiler_variant_substitutions
+  String? tbprofiler_output_seq_method_type = tbprofiler.tbprofiler_output_seq_method_type
   # Legionella pneumophila Typing
   File? legsta_results = legsta.legsta_results
   String? legsta_predicted_sbt = legsta.legsta_predicted_sbt

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -37,6 +37,8 @@ workflow merlin_magic {
     Boolean call_poppunk = true
     Boolean read1_is_ont = false
     Boolean call_shigeifinder_reads_input = false
+    Boolean tbprofiler_additional_outputs = false
+    String output_seq_method_type = "WGS"
   }
     if (merlin_tag == "Acinetobacter baumannii") {
     call kaptive.kaptive {
@@ -149,7 +151,9 @@ workflow merlin_magic {
       input:
         read1 = read1,
         read2 = read2,
-        samplename = samplename
+        samplename = samplename,
+        tbprofiler_additional_outputs = tbprofiler_additional_outputs,
+        output_seq_method_type = output_seq_method_type
     }
   }
   if (merlin_tag == "Legionella pneumophila") {

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -679,6 +679,11 @@ workflow theiaprok_illumina_pe {
     String? tbprofiler_sub_lineage = merlin_magic.tbprofiler_sub_lineage
     String? tbprofiler_dr_type = merlin_magic.tbprofiler_dr_type
     String? tbprofiler_resistance_genes = merlin_magic.tbprofiler_resistance_genes
+    File? tbprofiler_additional_outputs_csv = merlin_magic.tbprofiler_additional_outputs_csv
+    String? tbprofiler_gene_name = merlin_magic.tbprofiler_gene_name
+    String? tbprofiler_locus_tag = merlin_magic.tbprofiler_locus_tag
+    String? tbprofiler_variant_substitutions = merlin_magic.tbprofiler_variant_substitutions
+    String? tbprofiler_output_seq_method_type = merlin_magic.tbprofiler_output_seq_method_type
     # Legionella pneumophila typing
     File? legsta_results = merlin_magic.legsta_results
     String? legsta_predicted_sbt = merlin_magic.legsta_predicted_sbt

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -680,6 +680,7 @@ workflow theiaprok_illumina_pe {
     String? tbprofiler_dr_type = merlin_magic.tbprofiler_dr_type
     String? tbprofiler_resistance_genes = merlin_magic.tbprofiler_resistance_genes
     File? tbprofiler_additional_outputs_csv = merlin_magic.tbprofiler_additional_outputs_csv
+    File? tbprofiler_laboratorian_report_csv = merlin_magic.tbprofiler_laboratorian_report_csv
     String? tbprofiler_gene_name = merlin_magic.tbprofiler_gene_name
     String? tbprofiler_locus_tag = merlin_magic.tbprofiler_locus_tag
     String? tbprofiler_variant_substitutions = merlin_magic.tbprofiler_variant_substitutions

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -605,6 +605,11 @@ workflow theiaprok_illumina_se {
     String? tbprofiler_sub_lineage = merlin_magic.tbprofiler_sub_lineage
     String? tbprofiler_dr_type = merlin_magic.tbprofiler_dr_type
     String? tbprofiler_resistance_genes = merlin_magic.tbprofiler_resistance_genes
+    File? tbprofiler_additional_outputs_csv = merlin_magic.tbprofiler_additional_outputs_csv
+    String? tbprofiler_gene_name = merlin_magic.tbprofiler_gene_name
+    String? tbprofiler_locus_tag = merlin_magic.tbprofiler_locus_tag
+    String? tbprofiler_variant_substitutions = merlin_magic.tbprofiler_variant_substitutions
+    String? tbprofiler_output_seq_method_type = merlin_magic.tbprofiler_output_seq_method_type
     # Legionella pneumophila typing
     File? legsta_results = merlin_magic.legsta_results
     String? legsta_predicted_sbt = merlin_magic.legsta_predicted_sbt

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -606,6 +606,7 @@ workflow theiaprok_illumina_se {
     String? tbprofiler_dr_type = merlin_magic.tbprofiler_dr_type
     String? tbprofiler_resistance_genes = merlin_magic.tbprofiler_resistance_genes
     File? tbprofiler_additional_outputs_csv = merlin_magic.tbprofiler_additional_outputs_csv
+    File? tbprofiler_laboratorian_report_csv = merlin_magic.tbprofiler_laboratorian_report_csv
     String? tbprofiler_gene_name = merlin_magic.tbprofiler_gene_name
     String? tbprofiler_locus_tag = merlin_magic.tbprofiler_locus_tag
     String? tbprofiler_variant_substitutions = merlin_magic.tbprofiler_variant_substitutions


### PR DESCRIPTION
## Motivation

This PR adds a new behaviour, controlled by the `tbprofiler_additional_outputs` boolean (currently set to `true`) that controls 5 new outputs: `tb_profiler_variant_gene_name`, `tb_profiler_variant_locus_tag`, `tb_profiler_variant_substitutions`,  `tb_profiler_sequencing_method`, `tbprofiler_additional_outputs_csv` and `tbprofiler_laboratorian_csv`. 

These columns include information in all mutations found by tbprofiler with the following criteria:

- who catalogue associated with resistance, uncertain, and interim (not associated with resistance not included)
- mutation is not synonymous
- ALL mutations in **katG, pncA, rpoB, ethA and gid** included, except for synonymous mutations  

## Main changes

- tbprofiler container image was updated to `staphb/tbprofiler:4.4.2` 
- The following new output columns were included with information about each mutation in a comma-delimited list to be ingested into a BigQuery database for visualization in a Looker Dashboard:
  - **Column1:** tbprofiler_variant_gene_name
  - **Column2:** tbprofiler_variant_locus_tag
  - **Column3:** tbprofiler_variant_substitutions in the format `mutation_type:nt_sub(aa_sub` 
  - **Column4:** tbprofiler_sequencing_method
  - **Column5:** CSV file to be ingested into CDPH LIMS system with all the information above split into different columns
  - **Column6:** CSV file to be human readable with the same information as above, and additionally the depth of coverage, the frequency, and a warning if the coverage is below a threshold of 10 times. 

## Testing

- `tbprofiler_additional_outputs` set to `true`
  - [Theiaprok_Illumina_SE with 100 samples](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/c29d2ac7-177a-48a8-90c9-30f681cd4d03)
  - [Theiaprok_Illumina_PE with 100 samples](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/7a99d3c6-4136-4f3e-8bf1-8b2fa91cff8b)