### PR TITLE
add agrvate to S. aureus subwf pull request

### DIFF
--- a/tasks/species_typing/task_agrvate.wdl
+++ b/tasks/species_typing/task_agrvate.wdl
@@ -33,14 +33,53 @@ task agrvate {
     fasta_prefix=${basename%.*}
     
     # rename outputs summary TSV to include samplename
-    mv -v "${fasta_prefix}-results/${fasta_prefix}-summary.tab" ~{samplename}.tsv
+    mv -v "${fasta_prefix}-results/${fasta_prefix}-summary.tab" ~{samplename}.agrvate.tsv
+
+    # parse output summary TSV
+    cut -f 2 ~{samplename}.agrvate.tsv | tail -n 1 | tee AGR_GROUP
+    cut -f 3 ~{samplename}.agrvate.tsv | tail -n 1 | tee AGR_MATCH_SCORE
+    cut -f 4 ~{samplename}.agrvate.tsv | tail -n 1 | tee AGR_CANONICAL
+    cut -f 5 ~{samplename}.agrvate.tsv | tail -n 1 | tee AGR_MULTIPLE
+    cut -f 6 ~{samplename}.agrvate.tsv | tail -n 1 | tee AGR_NUM_FRAMESHIFTS
+
+    # edit output string AGR_CANONICAL to be more informative: https://github.com/VishnuRaghuram94/AgrVATE#results
+    if [[ $(cat AGR_CANONICAL) == 1 ]]; then
+      echo "1/canonical agrD" >AGR_CANONICAL
+    elif [[ $(cat AGR_CANONICAL) == 0 ]]; then
+      echo "0/non-canonical agrD" >AGR_CANONICAL
+    elif [[ $(cat AGR_CANONICAL) == "u" ]]; then
+      echo "u/unknown agrD" >AGR_CANNONICAL
+    else 
+      echo "result unrecognized, please see summary agrvate TSV file" >AGR_CANONICAL
+    fi
+
+    # edit output string AGR_MULTIPLE to be more informative: https://github.com/VishnuRaghuram94/AgrVATE#results
+    if [[ $(cat AGR_MULTIPLE) == "s" ]]; then
+      echo "s/single" >AGR_MULTIPLE
+    elif [[ $(cat AGR_MULTIPLE) == "m" ]]; then
+      echo "m/multiple" >AGR_MULTIPLE
+    elif [[ $(cat AGR_MULTIPLE) == "u" ]]; then
+      echo "u/unknown" >AGR_MULTIPLE
+    else 
+      echo "result unrecognized, please see summary agrvate TSV file" >AGR_MULTIPLE
+    fi
+
+    # if AGR_NUM_FRAMESHIFTS is unknown, edit output string AGR_NUM_FRAMESHIFTS to be more informative, otherwise keep set to a number: https://github.com/VishnuRaghuram94/AgrVATE#results
+    if [[ $(cat AGR_NUM_FRAMESHIFTS) == "u" ]]; then
+      echo "u/unknown, agr operon not extracted" >AGR_NUM_FRAMESHIFTS
+    fi
 
     # create tarball of all output files
-    tar -czvf ~{samplename}.tar.gz "${fasta_prefix}-results/"
+    tar -czvf ~{samplename}.agrvate.tar.gz "${fasta_prefix}-results/"
   >>>
   output {
-    File agrvate_summary = "~{samplename}.tsv"
-    File agrvate_results = "~{samplename}.tar.gz"
+    File agrvate_summary = "~{samplename}.agrvate.tsv"
+    File agrvate_results = "~{samplename}.agrvate.tar.gz"
+    String agrvate_agr_group = read_string("AGR_GROUP")
+    String agrvate_agr_match_score = read_string("AGR_MATCH_SCORE")
+    String agrvate_agr_canonical = read_string("AGR_CANONICAL")
+    String agrvate_agr_multiple = read_string("AGR_MULTIPLE")
+    String agrvate_agr_num_frameshifts = read_string("AGR_NUM_FRAMESHIFTS")
     String agrvate_version = read_string("VERSION")
     String agrvate_docker = docker
   }

--- a/tasks/species_typing/task_agrvate.wdl
+++ b/tasks/species_typing/task_agrvate.wdl
@@ -44,29 +44,29 @@ task agrvate {
 
     # edit output string AGR_CANONICAL to be more informative: https://github.com/VishnuRaghuram94/AgrVATE#results
     if [[ $(cat AGR_CANONICAL) == 1 ]]; then
-      echo "1/canonical agrD" >AGR_CANONICAL
+      echo "1. canonical agrD" >AGR_CANONICAL
     elif [[ $(cat AGR_CANONICAL) == 0 ]]; then
-      echo "0/non-canonical agrD" >AGR_CANONICAL
+      echo "0. non-canonical agrD" >AGR_CANONICAL
     elif [[ $(cat AGR_CANONICAL) == "u" ]]; then
-      echo "u/unknown agrD" >AGR_CANNONICAL
+      echo "u. unknown agrD" >AGR_CANNONICAL
     else 
       echo "result unrecognized, please see summary agrvate TSV file" >AGR_CANONICAL
     fi
 
     # edit output string AGR_MULTIPLE to be more informative: https://github.com/VishnuRaghuram94/AgrVATE#results
     if [[ $(cat AGR_MULTIPLE) == "s" ]]; then
-      echo "s/single" >AGR_MULTIPLE
+      echo "s. single agr group found" >AGR_MULTIPLE
     elif [[ $(cat AGR_MULTIPLE) == "m" ]]; then
-      echo "m/multiple" >AGR_MULTIPLE
+      echo "m. multiple agr groups found" >AGR_MULTIPLE
     elif [[ $(cat AGR_MULTIPLE) == "u" ]]; then
-      echo "u/unknown" >AGR_MULTIPLE
+      echo "u. unknown agr groups found" >AGR_MULTIPLE
     else 
       echo "result unrecognized, please see summary agrvate TSV file" >AGR_MULTIPLE
     fi
 
     # if AGR_NUM_FRAMESHIFTS is unknown, edit output string AGR_NUM_FRAMESHIFTS to be more informative, otherwise keep set to a number: https://github.com/VishnuRaghuram94/AgrVATE#results
     if [[ $(cat AGR_NUM_FRAMESHIFTS) == "u" ]]; then
-      echo "u/unknown, agr operon not extracted" >AGR_NUM_FRAMESHIFTS
+      echo "u or unknown; agr operon not extracted" >AGR_NUM_FRAMESHIFTS
     fi
 
     # create tarball of all output files

--- a/tasks/species_typing/task_agrvate.wdl
+++ b/tasks/species_typing/task_agrvate.wdl
@@ -22,7 +22,7 @@ task agrvate {
     # run agrvate on assembly; usearch not available in biocontainer, cannot use that option
     # using -m flag for mummer frameshift detection since usearch is not available
     agrvate \
-        ~{true="--typing_only" false="" typing_only} \
+        ~{true="--typing-only" false="" typing_only} \
         -i ~{assembly} \
         -m 
         

--- a/tasks/species_typing/task_agrvate.wdl
+++ b/tasks/species_typing/task_agrvate.wdl
@@ -8,30 +8,46 @@ task agrvate {
     File assembly
     String samplename
     String docker = "quay.io/biocontainers/agrvate:1.0.2--hdfd78af_0"
-    Int disk_size = 100
-    Int? cpu = 1
+    Int disk_size = 50
+    Int cpu = 1
 
     # Parameters
     # --typing_only    agr typing only. Skips agr operon extraction and frameshift detection
     Boolean typing_only = false
   }
   command <<<
-    echo $(agrvate -v 2>&1) | sed 's/agrvate v//;' | tee VERSION
+    # get version info
+    agrvate -v 2>&1 | sed 's/agrvate v//;' | tee VERSION
+
+    # run agrvate on assembly; usearch not available in biocontainer, cannot use that option
+    # using -m flag for mummer frameshift detection since usearch is not available
     agrvate \
         ~{true="--typing_only" false="" typing_only} \
-        -i $fasta_name
-    cp results/~{samplename}-summary.tab ~{samplename}.tsv
-    tar -czvf ~{samplename}.tar.gz results/
+        -i ~{assembly} \
+        -m 
+        
+    # agrvate names output directory and file based on name of .fasta file, so <prefix>.fasta as input results in <prefix>-results/ outdir
+    # and results in <prefix>-results/<prefix>-summary.tab files 
+    basename=$(basename ~{assembly})
+    # strip off anything after the period
+    fasta_prefix=${basename%.*}
+    
+    # rename outputs summary TSV to include samplename
+    mv -v "${fasta_prefix}-results/${fasta_prefix}-summary.tab" ~{samplename}.tsv
+
+    # create tarball of all output files
+    tar -czvf ~{samplename}.tar.gz "${fasta_prefix}-results/"
   >>>
   output {
     File agrvate_summary = "~{samplename}.tsv"
     File agrvate_results = "~{samplename}.tar.gz"
     String agrvate_version = read_string("VERSION")
+    String agrvate_docker = docker
   }
   runtime {
     docker: "~{docker}"
-    memory: "8 GB"
-    cpu: 4
+    memory: "4 GB"
+    cpu: cpu
     disks: "local-disk " + disk_size + " SSD"
     disk: disk_size + " GB"
     maxRetries: 3

--- a/tasks/utilities/task_broad_terra_tools.wdl
+++ b/tasks/utilities/task_broad_terra_tools.wdl
@@ -277,6 +277,15 @@ task export_taxon_tables {
     String? staphopiasccmec_types_and_mecA_presence
     String? staphopiasccmec_version
     String? staphopiasccmec_docker
+    File? agrvate_summary
+    File? agrvate_results
+    String? agrvate_agr_group
+    String? agrvate_agr_match_score
+    String? agrvate_agr_canonical
+    String? agrvate_agr_multiple
+    String? agrvate_agr_num_frameshifts
+    String? agrvate_version
+    String? agrvate_docker
   }
   command <<<
   
@@ -579,7 +588,16 @@ task export_taxon_tables {
       "staphopiasccmec_hamming_distance_tsv": "~{staphopiasccmec_hamming_distance_tsv}",
       "staphopiasccmec_types_and_mecA_presence": "~{staphopiasccmec_types_and_mecA_presence}",
       "staphopiasccmec_version": "~{staphopiasccmec_version}",
-      "staphopiasccmec_docker ": "~{staphopiasccmec_docker}"
+      "staphopiasccmec_docker ": "~{staphopiasccmec_docker}",
+      "agrvate_summary": "~{agrvate_summary}",
+      "agrvate_results": "~{agrvate_results}",
+      "agrvate_agr_group": "~{agrvate_agr_group}",
+      "agrvate_agr_match_score": "~{agrvate_agr_match_score}",
+      "agrvate_agr_canonical": "~{agrvate_agr_canonical}",
+      "agrvate_agr_multiple": "~{agrvate_agr_multiple}",
+      "agrvate_agr_num_frameshifts": "~{agrvate_agr_num_frameshifts}",
+      "agrvate_version": "~{agrvate_version}",
+      "agrvate_docker": "~{agrvate_docker}"
     }
 
     with open("~{samplename}_terra_table.tsv", "w") as outfile:

--- a/workflows/wf_merlin_magic.wdl
+++ b/workflows/wf_merlin_magic.wdl
@@ -17,6 +17,7 @@ import "../tasks/species_typing/task_ngmaster.wdl" as ngmaster_task
 import "../tasks/species_typing/task_meningotype.wdl" as meningotype_task
 import "../tasks/species_typing/task_spatyper.wdl" as spatyper_task
 import "../tasks/species_typing/task_staphopiasccmec.wdl" as staphopia_sccmec_task
+import "../tasks/species_typing/task_agrvate.wdl" as agrvate_task
 import "../tasks/species_typing/task_seroba.wdl" as seroba
 import "../tasks/species_typing/task_pbptyper.wdl" as pbptyper
 import "../tasks/species_typing/task_poppunk_streppneumo.wdl" as poppunk_spneumo
@@ -38,6 +39,7 @@ workflow merlin_magic {
     String? pasty_docker_image
     String? shigeifinder_docker_image
     String? staphopia_sccmec_docker_image
+    String? agrvate_docker_image
     Boolean paired_end = true
     Boolean call_poppunk = true
     Boolean read1_is_ont = false
@@ -190,6 +192,12 @@ workflow merlin_magic {
           assembly = assembly,
           samplename = samplename,
           docker = staphopia_sccmec_docker_image
+      }
+    call agrvate_task.agrvate {
+        input:
+          assembly = assembly,
+          samplename = samplename,
+          docker = agrvate_docker_image
       }
   }
   if (merlin_tag == "Streptococcus pneumoniae") {
@@ -372,6 +380,16 @@ workflow merlin_magic {
   String? staphopiasccmec_types_and_mecA_presence = staphopiasccmec.staphopiasccmec_types_and_mecA_presence
   String? staphopiasccmec_version = staphopiasccmec.staphopiasccmec_version
   String? staphopiasccmec_docker = staphopiasccmec.staphopiasccmec_docker
+  File? agrvate_summary = agrvate.agrvate_summary
+  File? agrvate_results = agrvate.agrvate_results
+  String? agrvate_agr_group = agrvate.agrvate_agr_group
+  String? agrvate_agr_match_score = agrvate.agrvate_agr_match_score
+  String? agrvate_agr_canonical = agrvate.agrvate_agr_canonical
+  String? agrvate_agr_multiple = agrvate.agrvate_agr_multiple
+  String? agrvate_agr_num_frameshifts = agrvate.agrvate_agr_num_frameshifts
+  String? agrvate_version = agrvate.agrvate_version
+  String? agrvate_docker = agrvate.agrvate_docker
+
   # Streptococcus pneumoniae Typing
   String? pbptyper_predicted_1A_2B_2X = pbptyper_task.pbptyper_predicted_1A_2B_2X
   File? pbptyper_pbptype_predicted_tsv = pbptyper_task.pbptyper_pbptype_predicted_tsv

--- a/workflows/wf_theiaprok_illumina_pe.wdl
+++ b/workflows/wf_theiaprok_illumina_pe.wdl
@@ -454,6 +454,15 @@ workflow theiaprok_illumina_pe {
             staphopiasccmec_types_and_mecA_presence = merlin_magic.staphopiasccmec_types_and_mecA_presence,
             staphopiasccmec_version = merlin_magic.staphopiasccmec_version,
             staphopiasccmec_docker = merlin_magic.staphopiasccmec_docker,
+            agrvate_summary = merlin_magic.agrvate_summary,
+            agrvate_results = merlin_magic.agrvate_results,
+            agrvate_agr_group = merlin_magic.agrvate_agr_group,
+            agrvate_agr_match_score = merlin_magic.agrvate_agr_match_score,
+            agrvate_agr_canonical = merlin_magic.agrvate_agr_canonical,
+            agrvate_agr_multiple = merlin_magic.agrvate_agr_multiple,
+            agrvate_agr_num_frameshifts = merlin_magic.agrvate_agr_num_frameshifts,
+            agrvate_version = merlin_magic.agrvate_version,
+            agrvate_docker = merlin_magic.agrvate_docker,
             seroba_version = merlin_magic.seroba_version,
             seroba_docker = merlin_magic.seroba_docker,
             seroba_serotype = merlin_magic.seroba_serotype,
@@ -752,6 +761,15 @@ workflow theiaprok_illumina_pe {
     String? staphopiasccmec_types_and_mecA_presence = merlin_magic.staphopiasccmec_types_and_mecA_presence
     String? staphopiasccmec_version = merlin_magic.staphopiasccmec_version
     String? staphopiasccmec_docker = merlin_magic.staphopiasccmec_docker
+    File? agrvate_summary = merlin_magic.agrvate_summary
+    File? agrvate_results = merlin_magic.agrvate_results
+    String? agrvate_agr_group = merlin_magic.agrvate_agr_group
+    String? agrvate_agr_match_score = merlin_magic.agrvate_agr_match_score
+    String? agrvate_agr_canonical = merlin_magic.agrvate_agr_canonical
+    String? agrvate_agr_multiple = merlin_magic.agrvate_agr_multiple
+    String? agrvate_agr_num_frameshifts = merlin_magic.agrvate_agr_num_frameshifts
+    String? agrvate_version = merlin_magic.agrvate_version
+    String? agrvate_docker = merlin_magic.agrvate_docker
     # Streptococcus pneumoniae Typing
     String? pbptyper_predicted_1A_2B_2X = merlin_magic.pbptyper_predicted_1A_2B_2X
     File? pbptyper_pbptype_predicted_tsv = merlin_magic.pbptyper_pbptype_predicted_tsv

--- a/workflows/wf_theiaprok_illumina_se.wdl
+++ b/workflows/wf_theiaprok_illumina_se.wdl
@@ -415,7 +415,16 @@ workflow theiaprok_illumina_se {
             staphopiasccmec_hamming_distance_tsv = merlin_magic.staphopiasccmec_hamming_distance_tsv,
             staphopiasccmec_types_and_mecA_presence = merlin_magic.staphopiasccmec_types_and_mecA_presence,
             staphopiasccmec_version = merlin_magic.staphopiasccmec_version,
-            staphopiasccmec_docker = merlin_magic.staphopiasccmec_docker
+            staphopiasccmec_docker = merlin_magic.staphopiasccmec_docker,
+            agrvate_summary = merlin_magic.agrvate_summary,
+            agrvate_results = merlin_magic.agrvate_results,
+            agrvate_agr_group = merlin_magic.agrvate_agr_group,
+            agrvate_agr_match_score = merlin_magic.agrvate_agr_match_score,
+            agrvate_agr_canonical = merlin_magic.agrvate_agr_canonical,
+            agrvate_agr_multiple = merlin_magic.agrvate_agr_multiple,
+            agrvate_agr_num_frameshifts = merlin_magic.agrvate_agr_num_frameshifts,
+            agrvate_version = merlin_magic.agrvate_version,
+            agrvate_docker = merlin_magic.agrvate_docker
         }
       }
     }
@@ -678,6 +687,15 @@ workflow theiaprok_illumina_se {
     String? staphopiasccmec_types_and_mecA_presence = merlin_magic.staphopiasccmec_types_and_mecA_presence
     String? staphopiasccmec_version = merlin_magic.staphopiasccmec_version
     String? staphopiasccmec_docker = merlin_magic.staphopiasccmec_docker
+    File? agrvate_summary = merlin_magic.agrvate_summary
+    File? agrvate_results = merlin_magic.agrvate_results
+    String? agrvate_agr_group = merlin_magic.agrvate_agr_group
+    String? agrvate_agr_match_score = merlin_magic.agrvate_agr_match_score
+    String? agrvate_agr_canonical = merlin_magic.agrvate_agr_canonical
+    String? agrvate_agr_multiple = merlin_magic.agrvate_agr_multiple
+    String? agrvate_agr_num_frameshifts = merlin_magic.agrvate_agr_num_frameshifts
+    String? agrvate_version = merlin_magic.agrvate_version
+    String? agrvate_docker = merlin_magic.agrvate_docker
     # Streptococcus pneumoniae Typing
     String? pbptyper_predicted_1A_2B_2X = merlin_magic.pbptyper_predicted_1A_2B_2X
     File? pbptyper_pbptype_predicted_tsv = merlin_magic.pbptyper_pbptype_predicted_tsv


### PR DESCRIPTION
Opened a separate branch to ease testing on Terra without disrupting anyone currently using the `cjk-saureus-subwf` branch.

This PR adds the tool `agrvate` to the merlin magic subworkflow for any samples identified as "Staphyloccus aureus" by GAMBIT.

~~Setting as a draft until I'm done testing in Terra~~ Testing in Terra is complete, I'm comfortable merging this into the `cjk-saureus-subwf` dev branch.

Tested both TheiaProk_Illumina_SE: https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/058e88f0-df97-4094-a7e7-08a312d959a2

and TheiaProk_Illumina_PE (failures here are due to test data, not code changes): https://app.terra.bio/#workspaces/cdph-terrabio-taborda-manual/curtis_sandbox/job_history/83b43378-ae76-488d-a70f-5f0b96ec9df2

## Changes

- updated `tasks/species_typing/task_agrvate.wdl`
  - lowered `disk_size` input var to `50`, don't need much space
  - fixed optional integer input syntax
  - removed unnecessary `echo` 
  - added helpful comments throughout
  - adjusted `agrvate` command to always use mummer with `-m` option since usearch is not available in the container (due to strict redistribution rules)
  - added code for parsing summary TSV from agrvate
  - added 6 new outputs:

```WDL
    File agrvate_summary = summary TSV
    File agrvate_results = tarball of all agrvate output files
    String agrvate_agr_group = final agr group desitnation
    String agrvate_agr_match_score = confidence in agr match, higher number the better. ranges 0-15. 15 is max
    String agrvate_agr_canonical = canonical or non-canonical agrD gene
    String agrvate_agr_multiple = number of agr groups found (expect only 1 per isolate)
    String agrvate_agr_num_frameshifts = number of frameshifts found in CDS of extracted agr operon (done during mummer step)
    String agrvate_version = version
    String agrvate_docker = docker image used
```
  - lowered RAM to 4GB - again not a computationally intensive task
  - runtime `cpu` now uses input variable `cpu`
- added agrvate outputs to export_taxon_tables task in `tasks/utilities/task_broad_terra_tools.wdl`
- added agrvate to merlin_magic workflow
  - added optional input `agrvate_docker_image` for when new versions are released
- added agrvate outputs to theiaprok_Illumina_pe and SE workflows

I have NOT adjusted CI, so after merging I expect to see some CI failures on the other PR. Currently the CI is setup to only run on pull requests to `main` branch and not to others, so we can fix the CI stuff on PR #213 